### PR TITLE
Button background doesn't rescale to fit button height. Easy fix.

### DIFF
--- a/source/css/Button.css
+++ b/source/css/Button.css
@@ -30,6 +30,7 @@
 	*/
 	/**/
 	background: #E1E1E1 url(../../images/gradient.png) repeat-x bottom;
+	background-size: contain;
 	/**/
 	text-overflow: ellipsis;
 	/* the following cause arcane problems on IE */


### PR DESCRIPTION
Currently, button gradient doesn't rescale to fit button height when specifying a different height for the widget. This fixes it.
