### PR TITLE
Popup rendering outside of window bounds with centered=true

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -87,10 +87,14 @@ enyo.kind({
 		}
 	},
 	updatePosition: function() {
-		if (this.centered) {
+
+		if( this.centered ) {
+
 			var d = this.calcViewportSize();
 			var b = this.getBounds();
-			this.addStyles("top: " + ((d.height-b.height)/2) + "px; left: " + ((d.width-b.width)/2) + "px;");
+			var l = ( ( d.width - b.width ) / 2 );
+			var t = ( ( d.height - b.height ) / 2 );
+			this.addStyles("top: " + ( t >= 0 ? t : 0 ) + "px; left: " + ( l >= 0 ? l : 0 ) + "px;");
 		}
 	},
 	showingChanged: function() {


### PR DESCRIPTION
For a large popup, it can render outside the window bounds. Usually happens when the popup has one set of content (smaller than full window) and a new set of content is rendered while the popup is still open.

My fix was to change the updatePosition in Popup.js.
