### PR TITLE
Adding menu & picker item select events & behavior

### DIFF
--- a/examples/Samples/menu.html
+++ b/examples/Samples/menu.html
@@ -13,6 +13,9 @@
 			name: "App",
 			kind: "Control",
 			classes: "onyx",
+			handlers: {
+				onMenuItemSelected: "menuItemSelected"
+			},
 			components: [
 				{style: "padding: 10px;", content: "Some popups in a toolbar:"},
 				{kind: "onyx.Toolbar", classes: "onyx-menu-toolbar", components: [
@@ -96,6 +99,7 @@
 							]}
 						]}
 					]},
+					{name:"menuSelection", content: "Menu Item: nothing selected", style: "text-align:center; padding-top:50px"},
 					{style: "height: 1000px;"}
 				]}
 			],
@@ -112,6 +116,9 @@
 			},
 			preventMenuActivate: function() {
 				return true;
+			},
+			menuItemSelected: function(inSender, inEvent) {
+				this.$.menuSelection.setContent("Menu Item: " + inEvent.originator.content + " Selected");
 			}
 		}))({fit: true}).write();
 	</script>

--- a/examples/Samples/picker.html
+++ b/examples/Samples/picker.html
@@ -21,6 +21,9 @@
 			name: "App",
 			kind: "FittableRows",
 			classes: "onyx enyo-unselectable",
+			handlers: {
+				onPickerItemSelected: "pickerItemSelected"
+			},
 			components: [
 				{kind: "onyx.Toolbar", content: "Pickers"},
 				{fit: true, classes: "onyx-toolbar-inline", style: "margin: 20px;", components: [
@@ -80,8 +83,9 @@
 							{content: "Outlook"},
 							{content: "Hotmail", active: true}
 						]}
-					]}
-				]}
+					]},
+					{name:"pickerSelection", content:"Picker Item: select something", style:"margin-left:200px"}
+				]},
 			],
 			create: function() {
 				this.inherited(arguments);
@@ -106,6 +110,9 @@
 			},
 			setupYear: function(inSender, inEvent) {
 				this.$.year.setContent(1900+inEvent.index);
+			},
+			pickerItemSelected: function(inSender, inEvent) {console.log(inEvent)
+				this.$.pickerSelection.setContent("Picker Item: " + inEvent.originator.content + " selected");
 			}
 		}))({fit: true}).write();
 	</script>

--- a/source/MenuDecorator.js
+++ b/source/MenuDecorator.js
@@ -9,7 +9,8 @@ enyo.kind({
 	classes: "onyx-popup-decorator enyo-unselectable",
 	handlers: {
 		onActivate: "activated",
-		onHide: "menuHidden"
+		onHide: "menuHidden",
+		onMenuItemSelected: "menuItemSelected"
 	},
 	activated: function(inSender, inEvent) {
 		this.requestHideTooltip();
@@ -44,5 +45,8 @@ enyo.kind({
 		if (!this.menuActive) {
 			this.inherited(arguments);
 		}
+	},
+	menuItemSelected: function(inSender, inEvent){
+		this.requestHideMenu();
 	}
 });

--- a/source/MenuItem.js
+++ b/source/MenuItem.js
@@ -1,9 +1,18 @@
 /**
  A menu item.
+
+ The onMenuItemSelected event is generated when the user taps a menu item. Note that since any control may be used with a MenuDecorator, you will need to generate the onMenuItemSelected event from these other controls yourself if you would like the MenuDecorator to receive the event and automatically close the menu.
  */
 enyo.kind({
 	name: "onyx.MenuItem",
 	kind: "enyo.Button",
 	tag: "div",
-	classes: "onyx-menu-item"
+	classes: "onyx-menu-item",
+	events: {
+		onMenuItemSelected: ""
+	},	
+	tap: function(inSender) {
+		this.inherited(arguments);
+		this.doMenuItemSelected();
+	}
 });

--- a/source/PickerDecorator.js
+++ b/source/PickerDecorator.js
@@ -4,9 +4,16 @@ enyo.kind({
 	classes: "onyx-picker-decorator",
 	defaultKind: "onyx.PickerButton",
 	handlers: {
-		onSelect: "selected"
+		onSelect: "selected",
+	},
+	events: {
+		onPickerItemSelected: ""
 	},
 	selected: function(inSender, inEvent) {
 		this.waterfallDown("onSelect", inEvent);
-	}
+	},
+	menuItemSelected: function(inSender, inEvent){
+		this.inherited(arguments);
+		this.doPickerItemSelected(inEvent);
+	}	
 });


### PR DESCRIPTION
Added two events:
onMenuItemSelected - sent when a menu item is selected
onPickerItemSelected - sent when a picker item is selected

The MenuDecorator kind handles the onMenuItemSelected event by closing
the menu (whereas before the menu would stay open on a menu item
select). The PickerDecorator kind does the same, based off it's
inheritance from the MenuDecorator kind, however it also sends a
pickerItemSelected event.

Also updated the menu & picker samples to demonstrate this.

These are in regards to ENYO-509 & ENYO-508 WIP kinds.
