### PR TITLE
Updating menus & pickers to use separate events for internal & client communication

### DIFF
--- a/examples/Samples/menu.html
+++ b/examples/Samples/menu.html
@@ -14,7 +14,7 @@
 			kind: "Control",
 			classes: "onyx",
 			handlers: {
-				onMenuItemSelected: "menuItemSelected"
+				onSelect: "itemSelected"
 			},
 			components: [
 				{style: "padding: 10px;", content: "Some popups in a toolbar:"},
@@ -117,7 +117,7 @@
 			preventMenuActivate: function() {
 				return true;
 			},
-			menuItemSelected: function(inSender, inEvent) {
+			itemSelected: function(inSender, inEvent) {
 				this.$.menuSelection.setContent("Menu Item: " + inEvent.originator.content + " Selected");
 			}
 		}))({fit: true}).write();

--- a/examples/Samples/picker.html
+++ b/examples/Samples/picker.html
@@ -22,7 +22,7 @@
 			kind: "FittableRows",
 			classes: "onyx enyo-unselectable",
 			handlers: {
-				onPickerItemSelected: "pickerItemSelected"
+				onSelect: "itemSelected"
 			},
 			components: [
 				{kind: "onyx.Toolbar", content: "Pickers"},
@@ -111,8 +111,8 @@
 			setupYear: function(inSender, inEvent) {
 				this.$.year.setContent(1900+inEvent.index);
 			},
-			pickerItemSelected: function(inSender, inEvent) {console.log(inEvent)
-				this.$.pickerSelection.setContent("Picker Item: " + inEvent.originator.content + " selected");
+			itemSelected: function(inSender, inEvent) {
+				this.$.pickerSelection.setContent("Picker Item: " + inEvent.selected.content + " selected");
 			}
 		}))({fit: true}).write();
 	</script>

--- a/source/FlyweightPicker.js
+++ b/source/FlyweightPicker.js
@@ -8,7 +8,11 @@ enyo.kind({
 	},
 	events: {
 		//* Sends the row index, and the row control, for decoration
-		onSetupItem: ""
+		onSetupItem: "",
+		onSelect: ""
+	},
+	handlers: {
+		onSelect: "itemSelect"
 	},
 	components: [
 		{name: "scroller", kind: "enyo.Scroller", strategyKind: "TouchScrollStrategy", components: [
@@ -47,9 +51,17 @@ enyo.kind({
 		// need to remove the class from control to make sure it won't apply to other rows
 		this.item.removeClass("selected");
 		var n = this.$.client.fetchRowNode(this.selected);
-		this.doSelect({selected: this.selected, content: n && n.textContent || this.item.content});
+		this.doChange({selected: this.selected, content: n && n.textContent || this.item.content});
 	},
 	itemTap: function(inSender, inEvent) {
 		this.setSelected(inEvent.rowIndex);
+		//Send the select event that we want the client to receive.
+		this.doSelect({selected: this.item, content: this.item.content})
+	},
+	itemSelect: function(inSender, inEvent) {
+		//Block all select events that aren't coming from this control. This is to prevent select events from MenuItems since they won't have the correct value in a Flyweight context.
+		if (inEvent.originator != this) {
+			return true;
+		}
 	}
 });

--- a/source/MenuDecorator.js
+++ b/source/MenuDecorator.js
@@ -9,8 +9,7 @@ enyo.kind({
 	classes: "onyx-popup-decorator enyo-unselectable",
 	handlers: {
 		onActivate: "activated",
-		onHide: "menuHidden",
-		onMenuItemSelected: "menuItemSelected"
+		onHide: "menuHidden"
 	},
 	activated: function(inSender, inEvent) {
 		this.requestHideTooltip();
@@ -45,8 +44,5 @@ enyo.kind({
 		if (!this.menuActive) {
 			this.inherited(arguments);
 		}
-	},
-	menuItemSelected: function(inSender, inEvent){
-		this.requestHideMenu();
 	}
 });

--- a/source/MenuItem.js
+++ b/source/MenuItem.js
@@ -1,7 +1,5 @@
 /**
  A menu item.
-
- The onMenuItemSelected event is generated when the user taps a menu item. Note that since any control may be used with a MenuDecorator, you will need to generate the onMenuItemSelected event from these other controls yourself if you would like the MenuDecorator to receive the event and automatically close the menu.
  */
 enyo.kind({
 	name: "onyx.MenuItem",
@@ -9,10 +7,11 @@ enyo.kind({
 	tag: "div",
 	classes: "onyx-menu-item",
 	events: {
-		onMenuItemSelected: ""
-	},	
+		onSelect: ""
+	},
 	tap: function(inSender) {
 		this.inherited(arguments);
-		this.doMenuItemSelected();
+		this.bubble("onRequestHideMenu");
+		this.doSelect({selected:this, content:this.content});
 	}
 });

--- a/source/Picker.js
+++ b/source/Picker.js
@@ -7,7 +7,7 @@ enyo.kind({
 		maxHeight: "200px"
 	},
 	events: {
-		onSelect: ""
+		onChange: ""
 	},
 	components: [
 		{name: "client", kind: "enyo.Scroller", strategyKind: "TouchScrollStrategy"}
@@ -50,8 +50,8 @@ enyo.kind({
 		}
 		if (this.selected) {
 			this.selected.addClass("selected");
-			this.doSelect({selected: this.selected, content: this.selected.content});
-		}
+			this.doChange({selected: this.selected, content: this.selected.content});
+		};
 	},
 	resizeHandler: function() {
 		this.inherited(arguments);			

--- a/source/PickerButton.js
+++ b/source/PickerButton.js
@@ -2,9 +2,9 @@ enyo.kind({
 	name: "onyx.PickerButton",
 	kind: "onyx.Button",
 	handlers: {
-		onSelect: "selected"
+		onChange: "change"
 	},
-	selected: function(inSender, inEvent) {
+	change: function(inSender, inEvent) {
 		this.setContent(inEvent.content);
 	}
 });

--- a/source/PickerDecorator.js
+++ b/source/PickerDecorator.js
@@ -4,16 +4,9 @@ enyo.kind({
 	classes: "onyx-picker-decorator",
 	defaultKind: "onyx.PickerButton",
 	handlers: {
-		onSelect: "selected",
+		onChange: "change"
 	},
-	events: {
-		onPickerItemSelected: ""
-	},
-	selected: function(inSender, inEvent) {
-		this.waterfallDown("onSelect", inEvent);
-	},
-	menuItemSelected: function(inSender, inEvent){
-		this.inherited(arguments);
-		this.doPickerItemSelected(inEvent);
-	}	
+	change: function(inSender, inEvent) {
+		this.waterfallDown("onChange", inEvent);
+	}
 });


### PR DESCRIPTION
Added a second event for client communication of item selection since the mix of inheritance and the decorator pattern made using onSelect for both menus and pickers too complicated and was actually already buggy in terms of communicating picker selections to the client. Now onChange is used rather than onSelect by the picker kinds to communicate changes between the activator (PickerButton), PickerDecorator and Picker. onSelect is now used by MenuItem to communicate to the client when a menu choice is made.

Note that FlyweightPicker stops the MenuItem onSelect event from reaching the client since it will not have the correct value in a flyweight context. FlyweightPicker sends its own onSelect event once it has the correct selected item value to send.
