### PR TITLE
Fix for ENYO-537 - picker buttons render on top of each other (sample app)

### DIFF
--- a/examples/Samples/picker.html
+++ b/examples/Samples/picker.html
@@ -13,6 +13,7 @@
 			text-transform: uppercase;
 		}
 	</style>
+
 </head>
 <body class="onyx">
 	<script>
@@ -25,55 +26,57 @@
 			},
 			components: [
 				{kind: "onyx.Toolbar", content: "Pickers"},
-				{fit: true, classes: "onyx-toolbar-inline", style: "margin: 20px;", components: [
-					{kind: "onyx.PickerDecorator", components: [
-						{},
-						{kind: "onyx.Picker", components: [
-							{content: "Gmail", active: true},
-							{content: "Yahoo"},
-							{content: "Outlook"},
-							{content: "Hotmail"}
-						]}
-					]},
-					{kind: "onyx.PickerDecorator", components: [
-						{kind: "onyx.Button", content: "Pick One...", style: "width: 200px"},
-						{kind: "onyx.Picker", components: [
-							{content: "Hello!"},
-							{content: "I am busy."},
-							{content: "Good Bye."}
-						]}
-					]},
-					{tag: "br"},
-					{style: "display: block; height: 150px;"},
-					{classes: "onyx-toolbar-inline", components: [
-						{content: "Integer", classes: "label"},
-						{kind: "onyx.PickerDecorator", components: [
-							{style: "min-width: 60px;"},
-							{name: "integerPicker", kind: "onyx.Picker"}
-						]}
-					]},
-					{classes: "onyx-toolbar-inline", components: [
-						{content: "Date", classes: "label"},
+				{kind: "Scroller", fit: true, components: [
+					{classes: "onyx-toolbar-inline", style: "margin: 20px;", components: [				
 						{kind: "onyx.PickerDecorator", components: [
 							{},
-							{name: "monthPicker", kind: "onyx.Picker"}
+							{kind: "onyx.Picker", components: [
+								{content: "Gmail", active: true},
+								{content: "Yahoo"},
+								{content: "Outlook"},
+								{content: "Hotmail"}
+							]}
 						]},
 						{kind: "onyx.PickerDecorator", components: [
-							{style: "min-width: 60px;"},
-							{name: "dayPicker", kind: "onyx.Picker"}
-						]}
-					]},
-					{classes: "onyx-toolbar-inline", components: [
-						{content: "Year", classes: "label"},
-						{kind: "onyx.PickerDecorator", components: [
-							{style: "min-width: 80px;"},
-							{name: "yearPicker", kind: "onyx.FlyweightPicker", count: 200, onSetupItem: "setupYear", components: [
-								{name: "year"}
+							{kind: "onyx.Button", content: "Pick One...", style: "width: 200px"},
+							{kind: "onyx.Picker", components: [
+								{content: "Hello!"},
+								{content: "I am busy."},
+								{content: "Good Bye."}
+							]}
+						]},
+						{tag: "br"},
+						{style: "display: block; height: 50px;"},
+						{classes: "onyx-toolbar-inline", components: [
+							{content: "Integer", classes: "label"},
+							{kind: "onyx.PickerDecorator", components: [
+								{style: "min-width: 60px;"},
+								{name: "integerPicker", kind: "onyx.Picker"}
+							]}
+						]},
+						{classes: "onyx-toolbar-inline", components: [
+							{content: "Date", classes: "label"},
+							{kind: "onyx.PickerDecorator", components: [
+								{},
+								{name: "monthPicker", kind: "onyx.Picker"}
+							]},
+							{kind: "onyx.PickerDecorator", components: [
+								{style: "min-width: 60px;"},
+								{name: "dayPicker", kind: "onyx.Picker"}
+							]}
+						]},
+						{classes: "onyx-toolbar-inline", components: [
+							{content: "Year", classes: "label"},
+							{kind: "onyx.PickerDecorator", components: [
+								{style: "min-width: 80px;"},
+								{name: "yearPicker", kind: "onyx.FlyweightPicker", count: 200, onSetupItem: "setupYear", components: [
+									{name: "year"}
+								]}
 							]}
 						]}
 					]}
 				]},
-				{classes: "onyx-toolbar-inline", style: "height: 50px; margin: 20px;", components: [
+				{classes: "onyx-toolbar-inline", style: "height: 50px; margin: 20px; padding-bottom:15px;", components: [
 					{kind: "onyx.PickerDecorator", components: [
 						{},
 						{kind: "onyx.Picker", components: [
@@ -83,7 +86,10 @@
 							{content: "Hotmail", active: true}
 						]}
 					]},
-					{name:"pickerSelection", content:"Picker Item: select something", style:"margin-left:200px"}
+					{kind: "onyx.Groupbox", style:"float:right;padding-left:10px;", components: [
+						{kind: "onyx.GroupboxHeader", content: "Selection"},
+						{name:"pickerSelection", content: "?", style:"text-align:center;"}
+					]}					
 				]},
 			],
 			create: function() {
@@ -111,7 +117,7 @@
 				this.$.year.setContent(1900+inEvent.index);
 			},
 			itemSelected: function(inSender, inEvent) {
-				this.$.pickerSelection.setContent("Picker Item: " + inEvent.selected.content + " selected");
+				this.$.pickerSelection.setContent(inEvent.selected.content);
 			}
 		}))({fit: true}).write();
 	</script>


### PR DESCRIPTION
Updated sample to use a scroller & adjusted a few components to lay out
better on smaller screens. Also made the selection output look a little
nicer.
