### PR TITLE
Update to menu.js & samples.

### DIFF
--- a/examples/Samples/menu.html
+++ b/examples/Samples/menu.html
@@ -17,7 +17,7 @@
 			},
 			components: [
 				{style: "padding: 10px;", content: "Some popups in a toolbar:"},
-				{kind: "onyx.Toolbar", classes: "onyx-menu-toolbar", components: [
+				{kind: "onyx.MoreToolbar", classes: "onyx-menu-toolbar", components: [
 					{kind: "onyx.TooltipDecorator", components: [
 						{kind: "onyx.Button", content: "Tooltip"},
 						{kind: "onyx.Tooltip", content: "I'm a tooltip for a button."}
@@ -117,7 +117,14 @@
 				return true;
 			},
 			itemSelected: function(inSender, inEvent) {
-				this.$.menuSelection.setContent("Menu Item: " + inEvent.originator.content + " Selected");
+				//Menu items send an onSelect event with a reference to themselves & any directly displayed content
+				if (inEvent.originator.content){
+					this.$.menuSelection.setContent(inEvent.originator.content + " Selected");			
+				} else if (inEvent.selected){
+					//	Since some of the menu items do not have directly displayed content (they are kinds with subcomponents),
+					//	we have to handle those items differently here.
+					this.$.menuSelection.setContent(inEvent.selected.controlAtIndex(1).content + " Selected");
+				}
 			}
 		}))({fit: true}).write();
 	</script>

--- a/samples/MenuSample.js
+++ b/samples/MenuSample.js
@@ -8,7 +8,7 @@ enyo.kind({
 	},
 	components: [
 		{style: "padding: 10px;", content: "Some popups in a toolbar:"},
-		{kind: "onyx.Toolbar", classes: "onyx-menu-toolbar", components: [
+		{kind: "onyx.MoreToolbar", classes: "onyx-menu-toolbar", components: [
 			{kind: "onyx.TooltipDecorator", components: [
 				{kind: "onyx.Button", content: "Tooltip"},
 				{kind: "onyx.Tooltip", content: "I'm a tooltip for a button."}
@@ -93,14 +93,11 @@ enyo.kind({
 			{kind: "onyx.Groupbox", classes:"onyx-sample-result-box", components: [
 				{kind: "onyx.GroupboxHeader", content: "Result"},
 				{name:"menuSelection", classes:"onyx-sample-result", content:"No menu selection yet."}
-			]},
-			{style: "height: 1000px;"}
+			]}
 		]}
 	],
 	create: function() {
 		this.inherited(arguments);
-		// FIXME: omg, no
-		this.$.menuScroller.$.strategy.$.client.addStyles("max-height: 200px;");
 	},
 	showPopup: function(inSender) {
 		var p = this.$[inSender.popup];
@@ -112,6 +109,13 @@ enyo.kind({
 		return true;
 	},
 	itemSelected: function(inSender, inEvent) {
-		this.$.menuSelection.setContent(inEvent.originator.content + " Selected");
+		//Menu items send an onSelect event with a reference to themselves & any directly displayed content
+		if (inEvent.originator.content){
+			this.$.menuSelection.setContent(inEvent.originator.content + " Selected");			
+		} else if (inEvent.selected){
+			//	Since some of the menu items do not have directly displayed content (they are kinds with subcomponents),
+			//	we have to handle those items differently here.
+			this.$.menuSelection.setContent(inEvent.selected.controlAtIndex(1).content + " Selected");
+		}
 	}
 });

--- a/source/Menu.js
+++ b/source/Menu.js
@@ -36,7 +36,6 @@ enyo.kind({
 		onRequestHideMenu: "requestHide"
 	},
 	itemActivated: function(inSender, inEvent) {
-		inEvent.originator.setActive(false);
 		return true;
 	},
 	showingChanged: function() {
@@ -106,5 +105,8 @@ enyo.kind({
 	resizeHandler: function() {
 		this.inherited(arguments);			
 		this.adjustPosition(true);	
+	},
+	requestHide: function(){
+		this.setShowing(false);
 	}
 });


### PR DESCRIPTION
- Removed setActive call when menu items are activated. Found this was
  no longer necessary with the current menu implementation (verified with
  menu, picker & flyweight picker), plus it was preventing the
  onyx.MoreToolbar from displaying menus.
- Updated menu sample to use more toolbar so it can be displayed on
  mobile.
