### PR TITLE
Reverting previous breaking change & adding proper fix

### DIFF
--- a/source/Menu.js
+++ b/source/Menu.js
@@ -36,6 +36,7 @@ enyo.kind({
 		onRequestHideMenu: "requestHide"
 	},
 	itemActivated: function(inSender, inEvent) {
+		inEvent.originator.setActive(false);
 		return true;
 	},
 	showingChanged: function() {

--- a/source/MenuDecorator.js
+++ b/source/MenuDecorator.js
@@ -32,8 +32,6 @@ enyo.kind({
 			this.activator = inEvent.originator;
 			this.activator.addClass("active");
 			this.requestShowMenu();
-		} else {
-			this.requestHideMenu();
 		}
 	},
 	requestShowMenu: function() {


### PR DESCRIPTION
Reverting change to Menu.js which was made to allow menus to be usable in MoreToolbar, but ended up breaking picker behavior. Adding in proper change to MenuDecorator to re-allow menus, pickers, etc to work in
MoreToolbar.

Related commit -
https://github.com/enyojs/onyx/commit/084b7d184699605dded59cdb9f7722a9c9
32141f
