### PR TITLE
ENYO-730: holding mouse down messes up SwipeableItem

### DIFF
--- a/source/SwipeableItem.js
+++ b/source/SwipeableItem.js
@@ -36,7 +36,7 @@ enyo.kind({
 	},
 	components: [
 		{name: "client", kind: "Slideable", min: -100, unit: "%", ondragstart: "clientDragStart"},
-		{name: "confirm", kind: "onyx.Toolbar", canGenerate: false, classes: "onyx-swipeable-item-confirm enyo-fit", style: "text-align: center;", ontap: "confirmTap", components: [
+		{name: "confirm", kind: "onyx.Toolbar", canGenerate: false, classes: "onyx-swipeable-item-confirm enyo-fit", style: "text-align: center;", ontap: "confirmTap", onhold: "doNothing", onrelease: "doNothing", components: [
 			{kind: "onyx.Button", content: "Delete", ontap: "deleteTap"},
 			{kind: "onyx.Button", content: "Cancel", ontap: "cancelTap"}
 		]}
@@ -138,5 +138,8 @@ enyo.kind({
 			}
 		}
 		return this.preventDragPropagation;
+	},
+	doNothing: function(inSender, inEvent) {
+		return true;
 	}
 });


### PR DESCRIPTION
Suppress the "hold" and "release" events when the item is swiped.
