### PR TITLE
added alwaysLooksFocused property to onyx.InputDecorator

### DIFF
--- a/source/InputDecorator.js
+++ b/source/InputDecorator.js
@@ -40,20 +40,20 @@ enyo.kind({
 	},
 	create:function() {
 		this.inherited(arguments);
-		this.alwaysLooksFocusedChanged();
+		this.updateFocus(false);
 	},
-	alwaysLooksFocusedChanged:function() {
-		if(!this.hasClass("onyx-focused") && this.alwaysLooksFocused) {
-			this.addClass("onyx-focused");
-		}
+	alwaysLooksFocusedChanged:function(oldValue) {
+		this.updateFocus(this.focus);
+	},
+	updateFocus:function(focus) {
+		this.focused = focus;
+		this.addRemoveClass("onyx-focused", this.alwaysLooksFocused || this.focused);
 	},
 	receiveFocus: function() {
-		this.addClass("onyx-focused");
+		this.updateFocus(true);
 	},
 	receiveBlur: function() {
-		if(!this.alwaysLooksFocused) {
-			this.removeClass("onyx-focused");
-		}
+		this.updateFocus(false);
 	},
 	disabledChange: function(inSender, inEvent) {
 		this.addRemoveClass("onyx-disabled", inEvent.originator.disabled);


### PR DESCRIPTION
Here's a quick test for the pull as well

enyo.kind({
    name:"ex.App",
    components:[
        {kind:"onyx.Groupbox", components:[
            {name:"id1", kind:"onyx.InputDecorator", alwaysLooksFocused:true, components:[
                {kind:"onyx.Input", style:"width:100%", placeholder:"Always looks focused"}
            ]},
            {name:"id2", kind:"onyx.InputDecorator", alwaysLooksFocused:true, components:[
                {kind:"onyx.Input", style:"width:100%", placeholder:"Always looks focused until first focus, then toggles", onfocus:"focused2"}
            ]},
            {name:"id3", kind:"onyx.InputDecorator", components:[
                {kind:"onyx.Input", style:"width:100%",  placeholder:"Looks unfocused until first focus, then stays focused", onfocus:"focused3"}
            ]}
        ]}
    ],
    focused2:function(source, event) {
        this.$.id2.setAlwaysLooksFocused(false);
    },
    focused3:function(source, event) {
        this.$.id3.setAlwaysLooksFocused(true);
    }
});
