### PR TITLE
Onyx-dark Class for Buttons

### DIFF
--- a/samples/ButtonSample.js
+++ b/samples/ButtonSample.js
@@ -10,6 +10,7 @@ enyo.kind({
 			{kind:"onyx.Button", content: "Affirmative", classes: "onyx-affirmative", ontap:"buttonTapped"},
 			{kind:"onyx.Button", content: "Negative", classes: "onyx-negative", ontap:"buttonTapped"},
 			{kind:"onyx.Button", content: "Blue", classes: "onyx-blue", ontap:"buttonTapped"},
+			{kind:"onyx.Button", content: "Dark", classes: "onyx-dark", ontap:"buttonTapped"},
 			{kind:"onyx.Button", content: "Custom", style: "background-color: purple; color: #F1F1F1;", ontap:"buttonTapped"}
 		]},
 		{classes: "onyx-sample-tools", components: [

--- a/source/css/onyx.css
+++ b/source/css/onyx.css
@@ -900,3 +900,8 @@
 	background-color: #C51616;
 	color: #F1F1F1;
 }
+
+.onyx-button.onyx-dark {
+	background-color: #555656;
+	color: #F2F2F2;
+}


### PR DESCRIPTION
Added an onyx-dark class for buttons, using the same background color as buttons in toolbars.
Also added a sample dark button to the button sampler.

Enyo-DCO-1.0-Signed-off-by: Jordan Gensler jordangens@gmail.com
