### PR TITLE
MoreToolbar clientLayoutKind

### DIFF
--- a/source/MoreToolbar.js
+++ b/source/MoreToolbar.js
@@ -29,6 +29,7 @@ enyo.kind({
 		onHide: "reflow"
 	},
 	published: {
+		//* Layout kind that will be applied to the client controls.
 		clientLayoutKind: "FittableColumnsLayout"
 	},
 	tools: [


### PR DESCRIPTION
Because of the nature of MoreToolbar, setting the layoutKind won't affect the client components. This adds a clientLayoutKind that lets you use FittableColumnsLayout in MoreToolbar. 

It's worth noting that I haven't tested this extensively.

Enyo-DCO-1.0-Signed-off-by: Jordan Gensler jordangens@gmail.com
