### PR TITLE
Add opera compatibility to progress animations

### DIFF
--- a/source/css/onyx.css
+++ b/source/css/onyx.css
@@ -717,6 +717,7 @@
 .onyx-progress-bar-bar.striped.animated {
 	-webkit-animation: progress-bar-stripes 2s linear infinite;
 	-moz-animation: progress-bar-stripes 2s linear infinite;
+	-o-animation: progress-bar-stripes 2s linear infinite;
 	animation: progress-bar-stripes 2s linear infinite;
 }
 
@@ -730,6 +731,15 @@
 }
 
 @-moz-keyframes progress-bar-stripes {
+  from {
+    background-position: 0 0;
+  }
+  to {
+    background-position: 40px 0;
+  }
+}
+
+@-o-keyframes progress-bar-stripes {
   from {
     background-position: 0 0;
   }


### PR DESCRIPTION
The progress animations use vendor-prefixed css animations. Add the -o- prefixed styles to the already existing -webkit- and -moz- prefixes.

Enyo-DCO-1.0-Signed-off-by: Chris Mondok chris.mondok@gmail.com
