### PR TITLE
Menu's scroller should be isChrome: true

### DIFF
--- a/source/Menu.js
+++ b/source/Menu.js
@@ -56,7 +56,7 @@ enyo.kind({
 	    this.maxHeightChanged();	
 	},
 	initComponents: function() {
-	    this.scrolling ? this.createComponents(this.childComponents) : enyo.nop;	
+	    this.scrolling ? this.createComponents(this.childComponents, {isChrome: true}) : enyo.nop;	
         this.inherited(arguments);
     },
 	getScroller: function() {


### PR DESCRIPTION
Otherwise, you can't rebuild the menu with new items via
destroyClientControls() and createComponent()

This is fallout from the fix for ENYO-689
