### PR TITLE
Workaround for android 4.0.3 rendering glitch. Also added back in positi...

### DIFF
--- a/source/Toolbar.js
+++ b/source/Toolbar.js
@@ -19,5 +19,13 @@
 */
 enyo.kind({
 	name: "onyx.Toolbar",
-	classes: "onyx onyx-toolbar onyx-toolbar-inline"
+	classes: "onyx onyx-toolbar onyx-toolbar-inline",
+	create: function(){
+		this.inherited(arguments);
+	
+		//workaround for android 4.0.3 rendering glitch (ENYO-674)
+		if (this.hasClass('onyx-menu-toolbar') && (enyo.platform.android >= 4)){
+			this.applyStyle("position", "static");
+		}
+	}
 });

--- a/source/css/onyx.css
+++ b/source/css/onyx.css
@@ -305,6 +305,7 @@
 
 /* customize a toolbar to support menus */
 .onyx-menu-toolbar, .onyx-toolbar.onyx-menu-toolbar {
+	position: relative;
 	z-index: 10; 
 	overflow: visible;
 }


### PR DESCRIPTION
...on:relative to onyx.css for onyx-menu-toolbar which all non-android platforms are happy with

Enyo-DCO-1.0-Signed-off-by: Steven Feaster Steven.Feaster@palm.com
