### PR TITLE
I fixed ENYO-762 issue. 

### DIFF
--- a/source/IconButton.js
+++ b/source/IconButton.js
@@ -35,9 +35,10 @@ enyo.kind({
 		if (this.disabled) {
 			return true;
 		}
-		this.setActive(true);
+		this.setActive(!this.active);
 	},
 	activeChanged: function() {
+		this.addRemoveClass("active", this.active);
 		this.bubble("onActivate");
 	}
 });

--- a/source/css/onyx.css
+++ b/source/css/onyx.css
@@ -31,7 +31,7 @@
 	vertical-align: middle;
 }
 
-.onyx-icon.onyx-icon-button.active, .onyx-icon.onyx-icon-button:active:hover {
+.onyx-icon.onyx-icon-button.active, .onyx-icon.onyx-icon-button:hover {
 	background-position: 0 -32px;
 }
 


### PR DESCRIPTION
Now IconButton shows it's bottom half image when it hovered -over or in an active state.
You can reference ENYO-762 (https://enyojs.atlassian.net/browse/ENYO-762)

Enyo-DCO-1.0-Signed-off-by: David UM david.um@lge.com
