### PR TITLE
Reverting TimePicker implementation to always update time format when ch...

### DIFF
--- a/samples/DatePickerSample.js
+++ b/samples/DatePickerSample.js
@@ -51,7 +51,7 @@ enyo.kind({
 			]},			
 			{content:"DATE W/DAYS HIDDEN",classes:"onyx-sample-divider"},			
 			{classes: "onyx-toolbar-inline", components: [
-				{name:"datePicker3", kind:"onyx.DatePicker", hideDay:true}
+				{name:"datePicker3", kind:"onyx.DatePicker", dayHidden:true}
 			]},
 			{kind: "onyx.Groupbox", style:"padding:5px;", components: [
 				{kind: "onyx.GroupboxHeader", content: "Value"},			

--- a/samples/TimePickerSample.js
+++ b/samples/TimePickerSample.js
@@ -65,6 +65,7 @@ enyo.kind({
 	formatTime: function(){				
 		this.$.timePicker1.setLocale(this.locale);
 		this.$.timePicker2.setLocale(this.locale);
+		this.$.timePicker2.setIs24HrMode(true);
 	},
 	resetTimes: function(date) {
 		var d = new Date();

--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -15,9 +15,9 @@ enyo.kind({
 		//* Current locale used for formatting. Can be set after control creation and control will reformat accordingly. 
 		locale: null,
 		//* Option to hide day, month or year fields		
-		hideDay: false,
-		hideMonth: false,
-		hideYear: false,
+		dayHidden: false,
+		monthHidden: false,
+		yearHidden: false,
 		//* Option to specify the minimum & maximum year values		
 		minYear: 1900,
 		maxYear: 2099,
@@ -54,9 +54,9 @@ enyo.kind({
 	
 		this.setupPickers(this._tf ? this._tf.getDateFieldOrder() : 'mdy');
 		
-		this.hideDayChanged();
-		this.hideMonthChanged();
-		this.hideYearChanged();
+		this.dayHiddenChanged();
+		this.monthHiddenChanged();
+		this.yearHiddenChanged();
 			
 		//Fill month, year & day pickers with values					
 		var d = this.value = this.value || new Date();
@@ -125,14 +125,14 @@ enyo.kind({
 	localeChanged: function() {
 		this.refresh();
 	},
-	hideDayChanged: function() {
-		this.$.dayPicker.getParent().setShowing(this.hideDay ? false : true);		
+	dayHiddenChanged: function() {
+		this.$.dayPicker.getParent().setShowing(this.dayHidden ? false : true);		
 	},
-	hideMonthChanged: function() {
-		this.$.monthPicker.getParent().setShowing(this.hideMonth ? false : true);
+	monthHiddenChanged: function() {
+		this.$.monthPicker.getParent().setShowing(this.monthHidden ? false : true);
 	},
-	hideYearChanged: function() {
-		this.$.yearPicker.getParent().setShowing(this.hideYear ? false : true);
+	yearHiddenChanged: function() {
+		this.$.yearPicker.getParent().setShowing(this.yearHidden ? false : true);
 	},
 	minYearChanged: function() {
 		this.refresh();		

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -12,7 +12,7 @@ enyo.kind({
 	published: {
 		//* Current locale used for formatting. Can be set after control creation and control will reformat accordingly. 		
 		locale: null,
-		//* Option to use 24 hour time		
+		//* Option to use 24 hour time, this is reset when locale is changed	
 		is24HrMode: null,
 		//* The current Date object. Passing a Date object to setValue will update the control accordingly & getValue returns a Date object				
 		value: null,		
@@ -74,7 +74,7 @@ enyo.kind({
             this.$.minutePicker.createComponent({content: (i < 10) ? ("0"+i):i, value:i, active: i == d.getMinutes()});
         }
 
-        // create am pm
+        // create am/pm
         if (d.getHours() >= 12) {
             this.$.ampmPicker.createComponents([{content: am},{content:pm, active: true}]);
         }
@@ -124,6 +124,8 @@ enyo.kind({
 		);		
 	},	
 	localeChanged: function() {
+		//reset 24 hour mode when changing locales
+		this.is24HrMode = null;
 		this.refresh();
 	},
 	is24HrModeChanged: function() {


### PR DESCRIPTION
...anging locales. Updated TimePicker sample to handle keeping 24 hour time example in 24 hour format. Also renamed DatePicker hideDay,hideMonth, hideYear properties to dayHidden, monthHidden & yearHidden + updated example to match.

Enyo-DCO-1.0-Signed-off-by: Steven Feaster steven.feaster@palm.com
