### PR TITLE
Remove focus-inner-border in Firefox-Windows

### DIFF
--- a/css/Button.less
+++ b/css/Button.less
@@ -64,3 +64,8 @@
 .onyx-button > img {
 	padding: 0px 3px;
 }
+
+/* Remove the focused inner-border style in Firefox (Windows) */
+.onyx-button::-moz-focus-inner {
+  border: 0;
+}

--- a/css/onyx.css
+++ b/css/onyx.css
@@ -143,6 +143,10 @@
 .onyx-button > img {
   padding: 0px 3px;
 }
+/* Remove the focused inner-border style in Firefox (Windows) */
+.onyx-button::-moz-focus-inner {
+  border: 0;
+}
 /* Checkbox.css */
 .onyx-checkbox {
   cursor: pointer;


### PR DESCRIPTION
This removes a Windows-only issue, where Firefox draws an inner-border
on focused buttons.

Enyo-DCO-1.1-Signed-off-by: Jeremy Thomas jeremy.thomas@palm.com
