### PR TITLE
Use en_us as default locale for Date and Time pickers

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -22,7 +22,7 @@ enyo.kind({
 			creation, in which case the control will be updated to reflect the
 			new value.
 		*/ 
-		locale: null,
+		locale: "en_us",
 		//* If true, the day field is hidden		
 		dayHidden: false,
 		//* If true, the month field is hidden
@@ -53,28 +53,21 @@ enyo.kind({
 	},
 	create: function() {
 		this.inherited(arguments);
-		if (!this.locale){
-			try {
-				this.locale = enyo.g11n.currentLocale().getLocale();
-			}
-			catch(err) {
-				this.locale = "en_us";
-			}	
+		if (enyo.g11n) {
+			this.locale = enyo.g11n.currentLocale().getLocale();
 		}
 		this.initDefaults();
 	},
 	initDefaults: function() {
-		var months;
+		// Fall back to en_us as default
+		var months = ["JAN", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
+
 		//Attempt to use the g11n lib (ie assume it is loaded)
-		try {
+		if (enyo.g11n) {
 			this._tf = new enyo.g11n.Fmts({locale:this.locale});
 			months = this._tf.getMonthFields();
 		}
-		catch(err) {
-			//Fall back to en_us as default
-			months = ["Jan", "FEB", "MAR", "APR", "MAY", "JUN", "JUL", "AUG", "SEP", "OCT", "NOV", "DEC"];
-		}	
-	
+
 		this.setupPickers(this._tf ? this._tf.getDateFieldOrder() : 'mdy');
 		
 		this.dayHiddenChanged();

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -19,7 +19,7 @@ enyo.kind({
 			creation, in which case the control will be updated to reflect the
 			new value.
 		*/
-		locale: null,
+		locale: "en_us",
 		//* If true, 24-hour time is used. This is reset when locale is changed.
 		is24HrMode: null,
 		/**
@@ -42,20 +42,16 @@ enyo.kind({
 	},	
 	create: function() {
 		this.inherited(arguments);
-		if (!this.locale){
-			try {
-				this.locale = enyo.g11n.currentLocale().getLocale();
-			}
-			catch(err) {
-				this.locale = "en_us";
-			}	
+		if (enyo.g11n) {
+			this.locale = enyo.g11n.currentLocale().getLocale();
 		}		
 		this.initDefaults();
 	},
 	initDefaults: function() {
-		var am, pm;
-		//Attempt to use the g11n lib (ie assume it is loaded)
-		try {
+		var am = "AM", pm = "PM";
+		this.is24HrMode = false;
+		// Attempt to use the g11n lib (ie assume it is loaded)
+		if (enyo.g11n) {
 			this._tf = new enyo.g11n.Fmts({locale:this.locale});
 			am = this._tf.getAmCaption();
 			pm = this._tf.getPmCaption();
@@ -63,12 +59,6 @@ enyo.kind({
 			if (this.is24HrMode == null) {
 				this.is24HrMode = !this._tf.isAmPm();				
 			}
-		}
-		catch(err) {
-			//fall back to en_us as default
-			am = "AM";
-			pm = "PM";
-			this.is24HrMode = false;
 		}	
 	
 		this.setupPickers(this._tf ? this._tf.getTimeFieldOrder() : 'hma');


### PR DESCRIPTION
Instead of using try/catch to see if the g11n module is available,  we test if the g11n is available by inspecting the enyo.g11n member. If is available we try to use the API, otherwise the defaults are used.

Enyo-DCO-1.1-Signed-off-by: Iván Perdomo katratxo@gmail.com
