### PR TITLE
Small fix for onyx.Toolbar styling when applying FittableColumnsLayout

### DIFF
--- a/css/Toolbar.less
+++ b/css/Toolbar.less
@@ -18,7 +18,7 @@
 	font-size: @onyx-toolbar-font-size;
 }
 
-.onyx-toolbar-inline > * {
+.onyx-toolbar-inline > *, .enyo-fittable-columns-layout.onyx-toolbar-inline > * {
 	display: inline-block;
 	vertical-align: middle;
 	margin: 4px 6px 5px;

--- a/css/onyx.css
+++ b/css/onyx.css
@@ -578,7 +578,8 @@
   overflow: hidden;
   font-size: 20px;
 }
-.onyx-toolbar-inline > * {
+.onyx-toolbar-inline > *,
+.enyo-fittable-columns-layout.onyx-toolbar-inline > * {
   display: inline-block;
   vertical-align: middle;
   margin: 4px 6px 5px;


### PR DESCRIPTION
This applies a small styling fix (by adding a more specific selector) to prevent the vertical alignment from getting screwy when using an onyx.Toolbar with `layoutKind: "FittableColumnsLayout"`.

One potential problem with this fix is that it requires the Onyx library to be aware of a class name that's actually part of the layout library. This isn't a great option from a design sense (if the classname changes in Layout, it'll break the Onyx functionality unless someone remembers to update the classname both places), but I couldn't think of a better way to handle it since both selectors are so darn specific.
