### PR TITLE
ENYO-1348: Menu in Toolbar is cut-off if class "onyx-menu-toolbar" is not added to Toolbar

### DIFF
--- a/css/Toolbar.less
+++ b/css/Toolbar.less
@@ -14,7 +14,7 @@
 	color: @onyx-toolbar-text-color;
 	/**/
 	white-space: nowrap;
-	overflow: hidden;
+	overflow-y: visible;
 	font-size: @onyx-toolbar-font-size;
 }
 


### PR DESCRIPTION
Menu in Toolbar is cut-off if class "onyx-menu-toolbar" is not added to Toolbar
