### PR TITLE
ENYO-1458: Allow dragging checkbox to propagate to scroller (was defeate...

### DIFF
--- a/source/Checkbox.js
+++ b/source/Checkbox.js
@@ -18,18 +18,17 @@ enyo.kind({
 	kind: enyo.Checkbox,
 	tag: "div",
 	handlers: {
-		ondown:"downHandler",
 		// prevent double onchange bubble in IE
 		onclick: ""
 	},
-	downHandler: function(inSender, e) {
+	tap: function(inSender, e) {
 		if (!this.disabled) {
 			this.setChecked(!this.getChecked());
 			this.bubble("onchange");
 		}
-		return true;
-	},
-	tap: function(inSender, e) {
 		return !this.disabled;
+	},
+	dragstart: function() {
+		// Override enyo.Input dragstart handler, to allow drags to propagate for Checkbox
 	}
 });


### PR DESCRIPTION
...d by default enyo.Input handling), and fire on change from tap rather than down.

Enyo-DCO-1.1-Signed-off-by: Kevin Schaaf kevin.schaaf@palm.com
