### PR TITLE
ENYO-1561 - Changes to the client.domCssText were not being preserved, a...

### DIFF
--- a/source/Drawer.js
+++ b/source/Drawer.js
@@ -93,6 +93,8 @@ enyo.kind({
 			this.$.client.hide();
 		}
 		else {
+			// save changes to this.domCssText --> see ENYO-1561
+			this.$.client.domCssText = enyo.Control.domStylesToCssText(this.$.client.domStyles);
 			// at end of open animation, clean limit on height/width
 			var v = (this.orient == "v");
 			var d = v ? "height" : "width";


### PR DESCRIPTION
...nd so the drawer was being drawn with a negative top position when the page was re-rendered.

Enyo-DCO-1.1-Signed-off-by: Chris Patalano chris.patalano@palm.com
