### PR TITLE
Moved activate event to occur when a menu item is created, but only if i...

### DIFF
--- a/samples/PickerSample.js
+++ b/samples/PickerSample.js
@@ -49,7 +49,7 @@ enyo.kind({
 			{classes: "onyx-toolbar-inline", style:"margin: 0px;", components: [
 				{content: "Year", classes: "onyx-sample-label"},
 				{kind: "onyx.PickerDecorator", components: [
-					{style: "min-width: 80px;"},
+					{name:"yearPickerButton", style: "min-width: 80px;"},
 					{name: "yearPicker", kind: "onyx.FlyweightPicker", count: 200, onSetupItem: "setupYear", components: [
 						{name: "year"}
 					]}
@@ -89,7 +89,7 @@ enyo.kind({
 		// year
 		var y = d.getYear();
 		this.$.yearPicker.setSelected(y);
-		this.$.year.setContent(1900+y);
+		this.$.yearPickerButton.setContent(1900+y);
 	},
 	setupYear: function(inSender, inEvent) {
 		this.$.year.setContent(1900+inEvent.index);

--- a/source/FlyweightPicker.js
+++ b/source/FlyweightPicker.js
@@ -76,6 +76,10 @@ enyo.kind({
 	initComponents: function() {
 		this.controlParentName = 'flyweight';
         this.inherited(arguments);
+		//Force the flyweight's client control (MenuItem is default) to activate. This will
+		//result in a call to processActivatedItem which preps our picker selection logic.
+		//This is a workaround for changes caused by ENYO-1609 which resulted in ENYO-1611.
+		this.$.flyweight.$.client.children[0].setActive(true);
     },
 	create: function() {
 		this.inherited(arguments);

--- a/source/MenuItem.js
+++ b/source/MenuItem.js
@@ -42,6 +42,12 @@ enyo.kind({
 	//* @protected
 	classes: "onyx-menu-item",
 	tag: "div",
+	create: function(){
+		this.inherited(arguments);
+		if (this.active){
+			this.bubble("onActivate");
+		}
+	},
 	tap: function(inSender) {
 		this.inherited(arguments);
 		this.bubble("onRequestHideMenu");


### PR DESCRIPTION
...t is set as the active item. Also adjust flyweight picker to force the client control to send an activate message on setup so that it sets up our current selection logic properly

Enyo-DCO-1.1-Signed-off-by: Steven Feaster steven.feaster@palm.com
