### PR TITLE
Workaround for FirefoxOS, which doesn't support :active:hover CSS selectors

### DIFF
--- a/css/Button.less
+++ b/css/Button.less
@@ -42,7 +42,7 @@
 
 	the effect is as if .onyx-button.active doesn't exist
 */
-.onyx-button.active {
+.onyx-button.active, .onyx-button.pressed {
 	background-image: @onyx-button-active-gradient;
 	background-position: top;
 	border-top: 1px solid rgba(15, 15, 15, 0.6);

--- a/css/Icon.less
+++ b/css/Icon.less
@@ -7,7 +7,7 @@
 	vertical-align: middle;
 }
 
-.onyx-icon.onyx-icon-button.active, .onyx-icon.onyx-icon-button:active:hover, .onyx-icon-toggle.active {
+.onyx-icon.onyx-icon-button.active, .onyx-icon.onyx-icon-button.pressed, .onyx-icon.onyx-icon-button:active:hover, .onyx-icon-toggle.active {
 	background-position: 0 -@onyx-icon-size;
 }
 

--- a/css/Slider.less
+++ b/css/Slider.less
@@ -19,6 +19,6 @@
 	margin: -23px -20px;
 }
 
-.onyx-slider-knob.active, .onyx-slider-knob:active:hover {
+.onyx-slider-knob.active, .onyx-slider-knob.pressed, .onyx-slider-knob:active:hover {
 	background-position: 0 -40px;
 }

--- a/css/onyx.css
+++ b/css/onyx.css
@@ -60,6 +60,7 @@
   vertical-align: middle;
 }
 .onyx-icon.onyx-icon-button.active,
+.onyx-icon.onyx-icon-button.pressed,
 .onyx-icon.onyx-icon-button:active:hover,
 .onyx-icon-toggle.active {
   background-position: 0 -32px;
@@ -116,7 +117,8 @@
 
 	the effect is as if .onyx-button.active doesn't exist
 */
-.onyx-button.active {
+.onyx-button.active,
+.onyx-button.pressed {
   background-image: url(./../images/gradient-invert.png);
   background-position: top;
   border-top: 1px solid rgba(15, 15, 15, 0.6);
@@ -787,6 +789,7 @@
   margin: -23px -20px;
 }
 .onyx-slider-knob.active,
+.onyx-slider-knob.pressed,
 .onyx-slider-knob:active:hover {
   background-position: 0 -40px;
 }

--- a/source/Button.js
+++ b/source/Button.js
@@ -19,5 +19,20 @@
 enyo.kind({
 	name: "onyx.Button",
 	kind: "enyo.Button",
-	classes: "onyx-button enyo-unselectable"
+	classes: "onyx-button enyo-unselectable",
+	//* @protected
+	create: function() {
+		//workaround for FirefoxOS which doesn't support :active:hover css selectors
+		if(enyo.platform.firefox && enyo.platform.touch) {
+			this.handlers.ondown = "down";
+			this.handlers.onleave = "leave";
+		}
+		this.inherited(arguments);
+	},
+	down: function(inSender, inEvent) {
+		this.addClass("pressed");
+	},
+	leave: function(inSender, inEvent) {
+		this.removeClass("pressed");
+	}
 });

--- a/source/IconButton.js
+++ b/source/IconButton.js
@@ -24,6 +24,20 @@ enyo.kind({
 	},
 	classes: "onyx-icon-button",
 	//* @protected
+	create: function() {
+		//workaround for FirefoxOS which doesn't support :active:hover css selectors
+		if(enyo.platform.firefox && enyo.platform.touch) {
+			this.handlers.ondown = "down";
+			this.handlers.onleave = "leave";
+		}
+		this.inherited(arguments);
+	},
+	down: function(inSender, inEvent) {
+		this.addClass("pressed");
+	},
+	leave: function(inSender, inEvent) {
+		this.removeClass("pressed");
+	},
 	rendered: function() {
 		this.inherited(arguments);
 		this.activeChanged();

--- a/source/Slider.js
+++ b/source/Slider.js
@@ -51,6 +51,11 @@ enyo.kind({
 	],
 	create: function() {
 		this.inherited(arguments);
+		//workaround for FirefoxOS which doesn't support :active:hover css selectors
+		if(enyo.platform.firefox && enyo.platform.touch) {
+			this.moreComponents[2].ondown = "down";
+			this.moreComponents[2].onup = "up";
+		}
 		this.createComponents(this.moreComponents);
 		this.valueChanged();
 	},
@@ -99,6 +104,12 @@ enyo.kind({
 			this.animateTo(v);
 			return true;
 		}
+	},
+	down: function(inSender, inEvent) {
+		this.addClass("pressed");
+	},
+	up: function(inSender, inEvent) {
+		this.removeClass("pressed");
 	},
 	//* @public
 	//* Animates to the given value.


### PR DESCRIPTION
Workaround for FirefoxOS, which doesn't support :active:hover CSS selectors

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason@canuckcoding.ca
