### PR TITLE
Remove background-image of decorated input controls on FirefoxOS

### DIFF
--- a/css/Input.less
+++ b/css/Input.less
@@ -28,6 +28,7 @@
 	outline: none;
 	cursor: pointer;
 	background-color: @onyx-input-background;
+	background-image: none;
 	font-size: @onyx-input-font-size;
 	box-shadow: none;
 	/* FIXME: hack for styling reset on Android */

--- a/css/RichText.less
+++ b/css/RichText.less
@@ -7,6 +7,7 @@
 	outline: none;
 	cursor: pointer;
 	background-color: @onyx-input-background;
+	background-image: none;
 	font-size: @onyx-richtext-font-size;
 	min-height: 20px;
 	min-width: 100px;

--- a/css/TextArea.less
+++ b/css/TextArea.less
@@ -7,6 +7,7 @@
 	outline: none;
 	cursor: pointer;
 	background-color: @onyx-input-background;
+	background-image: none;
 	font-size: @onyx-textarea-font-size;
 	box-shadow: none;
 	/* Remove scrollbars and resize handle */

--- a/css/onyx.css
+++ b/css/onyx.css
@@ -267,6 +267,7 @@
   outline: none;
   cursor: pointer;
   background-color: transparent;
+  background-image: none;
   font-size: 16px;
   box-shadow: none;
   /* FIXME: hack for styling reset on Android */
@@ -391,6 +392,7 @@
   outline: none;
   cursor: pointer;
   background-color: transparent;
+  background-image: none;
   font-size: 16px;
   box-shadow: none;
   /* Remove scrollbars and resize handle */
@@ -423,6 +425,7 @@
   outline: none;
   cursor: pointer;
   background-color: transparent;
+  background-image: none;
   font-size: 16px;
   min-height: 20px;
   min-width: 100px;


### PR DESCRIPTION
Fixed the text input controls so they don't have the odd background image gradient, when contained within an InputDecorator, on FirefoxOS
