### PR TITLE
Changed the FirefoxOS :active:hover css selector workaround to use onenter rather than ondown events as it seemed more appropriate and re-presses the control on re-entering a control

### DIFF
--- a/source/Button.js
+++ b/source/Button.js
@@ -24,12 +24,12 @@ enyo.kind({
 	create: function() {
 		//workaround for FirefoxOS which doesn't support :active:hover css selectors
 		if(enyo.platform.firefoxOS) {
-			this.handlers.ondown = "down";
+			this.handlers.onenter = "enter";
 			this.handlers.onleave = "leave";
 		}
 		this.inherited(arguments);
 	},
-	down: function(inSender, inEvent) {
+	enter: function(inSender, inEvent) {
 		this.addClass("pressed");
 	},
 	leave: function(inSender, inEvent) {

--- a/source/IconButton.js
+++ b/source/IconButton.js
@@ -27,12 +27,12 @@ enyo.kind({
 	create: function() {
 		//workaround for FirefoxOS which doesn't support :active:hover css selectors
 		if(enyo.platform.firefoxOS) {
-			this.handlers.ondown = "down";
+			this.handlers.onenter = "enter";
 			this.handlers.onleave = "leave";
 		}
 		this.inherited(arguments);
 	},
-	down: function(inSender, inEvent) {
+	enter: function(inSender, inEvent) {
 		this.addClass("pressed");
 	},
 	leave: function(inSender, inEvent) {

--- a/source/Slider.js
+++ b/source/Slider.js
@@ -53,7 +53,7 @@ enyo.kind({
 		this.inherited(arguments);
 		//workaround for FirefoxOS which doesn't support :active:hover css selectors
 		if(enyo.platform.firefoxOS) {
-			this.moreComponents[2].ondown = "down";
+			this.moreComponents[2].onenter = "enter";
 			this.moreComponents[2].onleave = "leave";
 		}
 		this.createComponents(this.moreComponents);
@@ -105,7 +105,7 @@ enyo.kind({
 			return true;
 		}
 	},
-	down: function(inSender, inEvent) {
+	enter: function(inSender, inEvent) {
 		this.addClass("pressed");
 	},
 	leave: function(inSender, inEvent) {


### PR DESCRIPTION
Changed the FirefoxOS :active:hover css selector workaround to use onenter rather than ondown events as it seemed more appropriate and re-presses the control on re-entering a control

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason@canuckcoding.ca
