### PR TITLE
 Fixed the FirefoxOS slider knob highlighting, and took into account the FirefoxOS Simulator which frustratingly does support :active:hover css selector

### DIFF
--- a/source/Button.js
+++ b/source/Button.js
@@ -25,17 +25,29 @@ enyo.kind({
 		//workaround for FirefoxOS which doesn't support :active:hover css selectors
 		//FirefoxOS simulator does :active:hover css selectors, so do additional srcEvent check
 		if(enyo.platform.firefoxOS) {
-			this.handlers.onenter = "enter";
-			this.handlers.onleave = "leave";
+			this.handlers.ondown = "fxosDown";
+			this.handlers.onenter = "fxosEnter";
+			this.handlers.ondrag = "fxosDrag";
+			this.handlers.onleave = "fxosLeave";
+			this.handlers.onup = "fxosUp";
 		}
 		this.inherited(arguments);
 	},
-	enter: function(inSender, inEvent) {
-		if(inEvent.srcEvent.type!="mouseover")
-			this.addClass("pressed");
+	fxosDown: function(inSender, inEvent) {
+		this.addClass("pressed");
+		this._isInControl = true;
 	},
-	leave: function(inSender, inEvent) {
-		if(inEvent.srcEvent.type!="mouseout")
-			this.removeClass("pressed");
+	fxosEnter: function(inSender, inEvent) {
+		this._isInControl = true;
+	},
+	fxosDrag: function(inSender, inEvent) {
+		this.addRemoveClass("pressed", this._isInControl);
+	},
+	fxosLeave: function(inSender, inEvent) {
+		this._isInControl = false;
+	},
+	fxosUp: function(inSender, inEvent) {
+		this.removeClass("pressed");
+		this._isInControl = false;
 	}
 });

--- a/source/IconButton.js
+++ b/source/IconButton.js
@@ -28,18 +28,30 @@ enyo.kind({
 		//workaround for FirefoxOS which doesn't support :active:hover css selectors
 		//FirefoxOS simulator does :active:hover css selectors, so do additional srcEvent check
 		if(enyo.platform.firefoxOS) {
-			this.handlers.onenter = "enter";
-			this.handlers.onleave = "leave";
+			this.handlers.ondown = "fxosDown";
+			this.handlers.onenter = "fxosEnter";
+			this.handlers.ondrag = "fxosDrag";
+			this.handlers.onleave = "fxosLeave";
+			this.handlers.onup = "fxosUp";
 		}
 		this.inherited(arguments);
 	},
-	enter: function(inSender, inEvent) {
-		if(inEvent.srcEvent.type!="mouseover")
-			this.addClass("pressed");
+	fxosDown: function(inSender, inEvent) {
+		this.addClass("pressed");
+		this._isInControl = true;
 	},
-	leave: function(inSender, inEvent) {
-		if(inEvent.srcEvent.type!="mouseout")
-			this.removeClass("pressed");
+	fxosEnter: function(inSender, inEvent) {
+		this._isInControl = true;
+	},
+	fxosDrag: function(inSender, inEvent) {
+		this.addRemoveClass("pressed", this._isInControl);
+	},
+	fxosLeave: function(inSender, inEvent) {
+		this._isInControl = false;
+	},
+	fxosUp: function(inSender, inEvent) {
+		this.removeClass("pressed");
+		this._isInControl = false;
 	},
 	rendered: function() {
 		this.inherited(arguments);

--- a/source/Slider.js
+++ b/source/Slider.js
@@ -54,8 +54,11 @@ enyo.kind({
 		//workaround for FirefoxOS which doesn't support :active:hover css selectors
 		//FirefoxOS simulator does :active:hover css selectors, so do additional srcEvent check
 		if(enyo.platform.firefoxOS) {
-			this.moreComponents[2].onenter = "enter";
-			this.moreComponents[2].onleave = "leave";
+			this.moreComponents[2].ondown = "fxosDown";
+			this.moreComponents[2].onenter = "fxosEnter";
+			this.moreComponents[2].ondrag = "fxosDrag";
+			this.moreComponents[2].onleave = "fxosLeave";
+			this.moreComponents[2].onup = "fxosUp";
 		}
 		this.createComponents(this.moreComponents);
 		this.valueChanged();
@@ -106,13 +109,22 @@ enyo.kind({
 			return true;
 		}
 	},
-	enter: function(inSender, inEvent) {
-		if(inEvent.srcEvent.type!="mouseover")
-			this.$.knob.addClass("pressed");
+	fxosDown: function(inSender, inEvent) {
+		this.$.knob.addClass("pressed");
+		this._isInControl = true;
 	},
-	leave: function(inSender, inEvent) {
-		if(inEvent.srcEvent.type!="mouseout")
-			this.$.knob.removeClass("pressed");
+	fxosEnter: function(inSender, inEvent) {
+		this._isInControl = true;
+	},
+	fxosDrag: function(inSender, inEvent) {
+		this.$.knob.addRemoveClass("pressed", this._isInControl);
+	},
+	fxosLeave: function(inSender, inEvent) {
+		this._isInControl = false;
+	},
+	fxosUp: function(inSender, inEvent) {
+		this.$.knob.removeClass("pressed");
+		this._isInControl = false;
 	},
 	//* @public
 	//* Animates to the given value.


### PR DESCRIPTION
 Fixed the FirefoxOS slider knob highlighting, and took into account the FirefoxOS Simulator which frustratingly does support :active:hover css selector

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason@canuckcoding.ca
