### PR TITLE
Edge-case fix for FirefoxOS where under certain conditions the css selector workaround doesn't un-press the control

### DIFF
--- a/source/Button.js
+++ b/source/Button.js
@@ -44,6 +44,7 @@ enyo.kind({
 		this.addRemoveClass("pressed", this._isInControl);
 	},
 	fxosLeave: function(inSender, inEvent) {
+		this.removeClass("pressed");
 		this._isInControl = false;
 	},
 	fxosUp: function(inSender, inEvent) {

--- a/source/IconButton.js
+++ b/source/IconButton.js
@@ -47,6 +47,7 @@ enyo.kind({
 		this.addRemoveClass("pressed", this._isInControl);
 	},
 	fxosLeave: function(inSender, inEvent) {
+		this.removeClass("pressed");
 		this._isInControl = false;
 	},
 	fxosUp: function(inSender, inEvent) {

--- a/source/Slider.js
+++ b/source/Slider.js
@@ -120,6 +120,7 @@ enyo.kind({
 		this.$.knob.addRemoveClass("pressed", this._isInControl);
 	},
 	fxosLeave: function(inSender, inEvent) {
+		this.$.knob.removeClass("pressed");
 		this._isInControl = false;
 	},
 	fxosUp: function(inSender, inEvent) {


### PR DESCRIPTION
Edge-case fix for FirefoxOS, where under certain conditions, the css selector workaround doesn't un-press the control

Enyo-DCO-1.1-Signed-off-by: Jason Robitaille jason@canuckcoding.ca
