### PR TITLE
Add silence calls around MenuItem create() to avoid sending messages dur...

### DIFF
--- a/source/MenuItem.js
+++ b/source/MenuItem.js
@@ -49,7 +49,9 @@ enyo.kind({
 	classes: "onyx-menu-item",
 	tag: "div",
 	create: function(){
+		this.silence();
 		this.inherited(arguments);
+		this.unsilence();
 		if (this.active){
 			this.bubble("onActivate");
 		}


### PR DESCRIPTION
...ing control creation -- that really slows down DatePicker and TimePicker control creation.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
