### PR TITLE
Enable JSHint es3 mode to find trailing commas

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -4,6 +4,7 @@
         "$L": false,
         "onyx": false
     },
+    "es3": true,
     "evil": false,
     "regexdash": true,
     "browser": true,

--- a/samples/SubmenuSample.js
+++ b/samples/SubmenuSample.js
@@ -10,10 +10,10 @@ enyo.kind({
 				{kind:"onyx.Submenu", content:"Sort by...", components:[
 					{content:"First Name"},
 					{content:"Last Name"},
-					{content:"Company"},
+					{content:"Company"}
 				]},
-				{content:"Sync"},
-			]},
+				{content:"Sync"}
+			]}
 		]},
 		{tag: "br"},
 		{classes: "onyx-sample-divider", content: "Nested Submenu"},
@@ -25,7 +25,7 @@ enyo.kind({
 				{kind:"onyx.Submenu", content:"Move to...", components:[
 					{kind:"onyx.Submenu", content:"Personal...", components:[
 						{content:"Games"},
-						{content:"Recpies"},
+						{content:"Recpies"}
 					]},
 					{kind:"onyx.Submenu", content:"Work...", components:[
 						{content:"Primary project"},


### PR DESCRIPTION
fix instance of that in SubmenuSample.js

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
