### PR TITLE
ENYO-3012: use `packagejs:` instead of `source:` in `deploy.json`

### DIFF
--- a/deploy.json
+++ b/deploy.json
@@ -1,5 +1,5 @@
 {
-	"source": ".",
+	"packagejs": "./package.js",
 	"assets": ["images", "LICENSE-2.0.txt"],
 	"libs": []
 }


### PR DESCRIPTION
- the `source:` property of `deploy.json` did not make sense as it was
  always refering  to the  folder where `deploy.json`  is.  it  is now
  replaced by a `packagejs:`  property (default: `"package.js"`) which
  indicates  where   is  the   relative  location  of   the  top-level
  `package.js` from the project root folder.

Enyo-DCO-1.1-Signed-off-by: Francois-Xavier KOWALSKI francois-xavier.kowalski@hp.com
