### PR TITLE
GF-12660 : Slider Samper drag issue

### DIFF
--- a/samples/SliderSample.js
+++ b/samples/SliderSample.js
@@ -81,7 +81,7 @@ enyo.kind({
 	},
 	updateRangeLabels: function(slider) {
 		slider.setStartLabel("--> " + Math.floor(slider.getRangeStart()));
-		slider.setEndLabel(Math.floor(slider.getRangeEnd()) + "<--");
+		slider.setEndLabel(Math.ceil(slider.getRangeEnd()) + "<--");
 	},
 	rangeSliderChanging: function(inSender, inEvent) {
 		this.updateRangeLabels(inSender);


### PR DESCRIPTION
In Slider Sampler in Onyx, slider value isn't reach until max value. The
reason is Math.floor func is used. So I did change from Math.floor to
Math.ceil.
Enyo-DCO-1.1-Signed-off-by: Changgi Lee changgi.lee@lge.com
