### PR TITLE
Add enyo namespace to underspecified kind strings

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -12,7 +12,7 @@
 */
 enyo.kind({
 	name: "onyx.Popup",
-	kind: "Popup",
+	kind: "enyo.Popup",
 	classes: "onyx-popup",
 	published: {
 		/**

--- a/source/ProgressBar.js
+++ b/source/ProgressBar.js
@@ -43,7 +43,7 @@ enyo.kind({
 	},
 	//* @protected
 	components: [
-		{name: "progressAnimator", kind: "Animator", onStep: "progressAnimatorStep", onEnd: "progressAnimatorComplete"},
+		{name: "progressAnimator", kind: "enyo.Animator", onStep: "progressAnimatorStep", onEnd: "progressAnimatorComplete"},
 		{name: "bar", classes: "onyx-progress-bar-bar"}
 	],
 	create: function() {

--- a/source/ProgressButton.js
+++ b/source/ProgressButton.js
@@ -22,7 +22,7 @@ enyo.kind({
 	},
 	//* @protected
 	components: [
-		{name: "progressAnimator", kind: "Animator", onStep: "progressAnimatorStep", onEnd: "progressAnimatorComplete"},
+		{name: "progressAnimator", kind: "enyo.Animator", onStep: "progressAnimatorStep", onEnd: "progressAnimatorComplete"},
 		{name: "bar", classes: "onyx-progress-bar-bar onyx-progress-button-bar"},
 		{name: "client", classes: "onyx-progress-button-client"},
 		{kind: "onyx.Icon", src: "$lib/onyx/images/progress-button-cancel.png", classes: "onyx-progress-button-icon", ontap: "cancelTap"}

--- a/source/RadioButton.js
+++ b/source/RadioButton.js
@@ -7,6 +7,6 @@
 */
 enyo.kind({
 	name: "onyx.RadioButton",
-	kind: "Button",
+	kind: "enyo.Button",
 	classes: "onyx-radiobutton"
 });

--- a/source/RadioGroup.js
+++ b/source/RadioGroup.js
@@ -11,7 +11,7 @@
 */
 enyo.kind({
 	name: "onyx.RadioGroup",
-	kind: "Group",
+	kind: "enyo.Group",
 	defaultKind: "onyx.RadioButton",
 	//* @protected
 	// set to true to provide radio button behavior

--- a/source/TabBar.js
+++ b/source/TabBar.js
@@ -47,7 +47,7 @@ not be selected.
 
 enyo.kind ({
 	name: 'onyx.TabBar',
-	kind: "FittableColumns",
+	kind: "enyo.FittableColumns",
 	isPanel: true,
 	classes: "onyx-tab-bar",
 
@@ -105,7 +105,7 @@ enyo.kind ({
 	components: [
 		{
 			name: "scroller",
-			kind: "Scroller",
+			kind: "enyo.Scroller",
 			fit:true,
 			maxHeight: "100px",
 

--- a/source/TabBarItem.js
+++ b/source/TabBarItem.js
@@ -28,7 +28,7 @@ enyo.kind ({
 	},
 	components: [
 		{
-			kind: "Button", // no need of onyx.RadioButton
+			kind: "enyo.Button", // no need of onyx.RadioButton
 			name: 'button',
 			ontap: 'setActiveTrue',
 			onmouseover: 'showTooltipFromTab',
@@ -115,9 +115,9 @@ enyo.kind ({
 		this.doTabCloseRequest({ index: this.tabIndex });
 		return true;
 	},
-	
+
 	showTooltipFromTab: function(inSender, inEvent){
 		this.doShowTooltip({tooltipContent: this.tooltipMsg, bounds:this.getBounds()});
-		
+
 	}
 });

--- a/source/TabPanels.js
+++ b/source/TabPanels.js
@@ -8,7 +8,7 @@ Here's an example:
 
 		enyo.kind({
 			name: "App",
-			kind: "TabPanels",
+			kind: "onyx.TabPanels",
 			fit: true,
 			components: [
 				{kind: "MyStartPanel"},
@@ -21,7 +21,7 @@ Here's an example:
 
 enyo.kind({
 	name: "onyx.TabPanels",
-	kind: "Panels",
+	kind: "enyo.Panels",
 	//* @protected
 	draggable: false,
 


### PR DESCRIPTION
Due to the nature of kind deferral in Enyo 2.3, we had
a problem where onyx.Popup could be undeferred after you
called enyo.registerTheme. When that happened, the code
would try to make onyx.Popup the base kind of onyx.Popup,
because the bare string "Popup" was found in the theme.

This change is an audit of all of the onyx code to
clarify any bare strings as kind name usage so they resolve
to the right kinds no matter when they're undeferred.

Enyo-DCO-1.1-Signed-Off-By: Ben Combee (ben.combee@lge.com)
