### PR TITLE
ENYO-1836: Update onyx.design with missing components and components to ignore in the palette's designer of Ares

### DIFF
--- a/onyx.design
+++ b/onyx.design
@@ -5,16 +5,14 @@
             "items": [
                 {
                     "name": "onyx.Button",
-                    "kind": "onyx.Button",
                     "description": "A pushbutton",
                     "config": {
-                        "content": "Button",
-                        "kind": "onyx.Button"
+                        "kind": "onyx.Button",
+                        "content": "Button"                        
                     }
                 },
                 {
                     "name": "onyx.Checkbox",
-                    "kind": "onyx.Checkbox",
                     "description": "A checkbox",
                     "config": {
                         "kind": "onyx.Checkbox"
@@ -22,7 +20,6 @@
                 },
                 {
                     "name": "onyx.Drawer",
-                    "kind": "onyx.Drawer",
                     "description": "A drawer that opens and closes",
                     "config": {
                         "kind": "onyx.Drawer"
@@ -30,7 +27,6 @@
                 },
                 {
                     "name": "onyx.Grabber",
-                    "kind": "onyx.Grabber",
                     "description": "Graphical 'handle' for dragging",
                     "config": {
                         "kind": "onyx.Grabber"
@@ -38,7 +34,6 @@
                 },
                 {
                     "name": "onyx.Icon",
-                    "kind": "onyx.Icon",
                     "description": "An icon",
                     "config": {
                         "kind": "onyx.Icon"
@@ -46,7 +41,6 @@
                 },
                 {
                     "name": "onyx.IconButton",
-                    "kind": "onyx.IconButton",
                     "description": "An icon button",
                     "config": {
                         "kind": "onyx.IconButton"
@@ -54,7 +48,6 @@
                 },
                 {
                     "name": "onyx.InputDecorator",
-                    "kind": "onyx.InputDecorator",
                     "description": "Style an input",
                     "config": {
                         "kind": "onyx.InputDecorator",
@@ -68,7 +61,6 @@
                 },
                 {
                     "name": "onyx.Input",
-                    "kind": "onyx.Input",
                     "description": "Text input control",
                     "config": {
                         "kind": "onyx.Input"
@@ -76,7 +68,6 @@
                 },
                 {
                     "name": "onyx.Item",
-                    "kind": "onyx.Item",
                     "description": "Stackable item, for lists and menus",
                     "config": {
                         "content": "Item",
@@ -85,7 +76,6 @@
                 },
                 {
                     "name": "onyx.ProgressBar",
-                    "kind": "onyx.ProgressBar",
                     "description": "A progress bar",
                     "config": {
                         "kind": "onyx.ProgressBar"
@@ -93,7 +83,6 @@
                 },
                 {
                     "name": "onyx.ProgressButton",
-                    "kind": "onyx.ProgressButton",
                     "description": "A progress button",
                     "config": {
                         "kind": "onyx.ProgressButton"
@@ -101,7 +90,6 @@
                 },
                 {
                     "name": "onyx.RangeSlider",
-                    "kind": "onyx.RangeSlider",
                     "description": "A slider with two knobs",
                     "config": {
                         "kind": "onyx.RangeSlider"
@@ -109,7 +97,6 @@
                 },
                 {
                     "name": "onyx.RichText",
-                    "kind": "onyx.RichText",
                     "description": "A rich text input",
                     "config": {
                         "kind": "onyx.RichText",
@@ -118,7 +105,6 @@
                 },
                 {
                     "name": "onyx.Scrim",
-                    "kind": "onyx.Scrim",
                     "description": "A overlay area to prevent tap events",
                     "config": {
                         "kind": "onyx.Scrim"
@@ -126,7 +112,6 @@
                 },
                 {
                     "name": "onyx.Slider",
-                    "kind": "onyx.Slider",
                     "description": "A slider",
                     "config": {
                         "kind": "onyx.Slider"
@@ -134,7 +119,6 @@
                 },
                 {
                     "name": "onyx.Spinner",
-                    "kind": "onyx.Spinner",
                     "description": "A spinner",
                     "config": {
                         "kind": "onyx.Spinner",
@@ -143,7 +127,6 @@
                 },
                 {
                     "name": "onyx.TextArea",
-                    "kind": "onyx.TextArea",
                     "description": "A multi-line text input",
                     "config": {
                         "kind": "onyx.TextArea"
@@ -151,7 +134,6 @@
                 },
                 {
                     "name": "onyx.ToggleButton",
-                    "kind": "onyx.ToggleButton",
                     "description": "A pushbutton that toggles between active and inactive states",
                     "config": {
                         "kind": "onyx.ToggleButton"
@@ -159,7 +141,6 @@
                 },
                 {
                     "name": "onyx.ToggleIconButton",
-                    "kind": "onyx.ToggleIconButton",
                     "description": "A pushbutton that toggles between active and inactive images",
                     "config": {
                         "kind": "onyx.ToggleIconButton"
@@ -172,7 +153,6 @@
             "items": [
                 {
                     "name": "onyx.Groupbox",
-                    "kind": "onyx.Groupbox",
                     "description": "A container for a group of controls",
                     "config": {
                         "kind": "onyx.Groupbox",
@@ -190,7 +170,6 @@
                 },
                 {
                     "name": "onyx.GroupboxHeader",
-                    "kind": "onyx.GroupboxHeader",
                     "description": "A header for the Groupbox",
                     "config": {
                         "content": "Header",
@@ -204,7 +183,6 @@
             "items": [
                 {
                     "name": "onyx.MenuDecorator",
-                    "kind": "onyx.MenuDecorator",
                     "description": "A menu and activating control",
                     "config": {
                         "kind": "onyx.MenuDecorator",
@@ -238,7 +216,6 @@
                 },
                 {
                     "name": "onyx.Menu",
-                    "kind": "onyx.Menu",
                     "description": "A menu",
                     "config": {
                         "kind": "onyx.Menu",
@@ -252,7 +229,6 @@
                 },
                 {
                     "name": "onyx.MenuItem",
-                    "kind": "onyx.MenuItem",
                     "description": "Stackable item for menus",
                     "config": {
                         "kind": "onyx.MenuItem"
@@ -260,7 +236,6 @@
                 },
                 {
                     "name": "onyx.Submenu",
-                    "kind": "onyx.Submenu",
                     "description": "A sub-menu",
                     "config": {
                         "kind": "onyx.Submenu",
@@ -279,7 +254,6 @@
             "items": [ 
                 {
                     "name": "onyx.DatePicker",
-                    "kind": "onyx.DatePicker",
                     "description": "A control for choosing a date",
                     "config": {
                         "kind": "onyx.DatePicker"
@@ -287,7 +261,6 @@
                 },
                 {
                     "name": "onyx.FlyweightPicker",
-                    "kind": "onyx.FlyweightPicker",
                     "description": "A control for choosing an item in a list by a flyweight pattern", 
                     "config": {
                         "kind": "onyx.FlyweightPicker"
@@ -295,7 +268,6 @@
                 },
                 {
                     "name": "onyx.IntegerPicker",
-                    "kind": "onyx.IntegerPicker",
                     "description": "A control for picking an integer value", 
                     "config": {
                         "kind": "onyx.IntegerPicker"
@@ -303,7 +275,6 @@
                 },
                 {
                     "name": "onyx.PickerDecorator",
-                    "kind": "onyx.PickerDecorator",
                     "description": "A picker and activating control",
                     "config": {
                         "kind": "onyx.PickerDecorator",
@@ -334,7 +305,6 @@
                 },
                 {
                     "name": "onyx.Picker",
-                    "kind": "onyx.Picker",
                     "description": "A control for choosing an item in a list", 
                     "config": {
                         "kind": "onyx.Picker"
@@ -342,7 +312,6 @@
                 },
                 {
                     "name": "onyx.PickerButton",
-                    "kind": "onyx.PickerButton",
                     "description": "A control to show a list of items to choose in a picker", 
                     "config": {
                         "kind": "onyx.PickerButton"
@@ -350,7 +319,6 @@
                 },
                 {
                     "name": "onyx.TimePicker",
-                    "kind": "onyx.TimePicker",
                     "description": "A Picker for time",
                     "config": {
                         "kind": "onyx.TimePicker"
@@ -363,7 +331,6 @@
             "items": [ 
                 {
                     "name": "onyx.ContextualPopup",
-                    "kind": "onyx.ContextualPopup",
                     "description": "A contextual popup",
                     "config": {
                         "kind": "onyx.ContextualPopup"
@@ -371,7 +338,6 @@
                 },
                 {
                     "name": "onyx.Popup",
-                    "kind": "onyx.Popup",
                     "description": "A popup",
                     "config": {
                         "kind": "onyx.Popup"
@@ -384,7 +350,6 @@
             "items": [ 
                 {
                     "name": "onyx.RadioGroup",
-                    "kind": "onyx.RadioGroup",
                     "description": "Only one control in a group can be 'active' at a time",
                     "config": {
                         "kind": "onyx.RadioGroup",
@@ -397,7 +362,6 @@
                 },
                 {
                     "name": "onyx.RadioButton",
-                    "kind": "onyx.RadioButton",
                     "description": "An on-off button, for use with RadioGroup",
                     "config": {
                         "content": "Button",
@@ -411,7 +375,6 @@
             "items": [ 
                 {
                     "name": "onyx.Toolbar",
-                    "kind": "onyx.Toolbar",
                     "description": "A toolbar",
                     "config": {
                         "kind": "onyx.Toolbar"
@@ -419,7 +382,6 @@
                 },
                 {
                     "name": "onyx.MoreToolbar",
-                    "kind": "onyx.MoreToolbar",
                     "description": "A toolbar which adapts to screen width",
                     "config": {
                         "kind": "onyx.MoreToolbar",
@@ -469,7 +431,6 @@
             "items": [ 
                 {
                     "name": "onyx.TooltipDecorator",
-                    "kind": "onyx.TooltipDecorator",
                     "description": "Combines a control (typically a button) and a tooltip describing it",
                     "config": {
                         "kind": "onyx.TooltipDecorator",
@@ -487,7 +448,6 @@
                 },
                 {
                     "name": "onyx.Tooltip",
-                    "kind": "onyx.Tooltip",
                     "description": "A tooltip",
                     "config": {
                         "kind": "onyx.Tooltip"


### PR DESCRIPTION
Related JIRA: https://enyojs.atlassian.net/browse/ENYO-1836

Update onyx.design with missing components and components to ignore in the designer's palette of Ares. Lighten components description, management

Must be reviewed (first) by @yves-del-medico and is related to other PRs:
- https://github.com/enyojs/ares-project/pull/632
- https://github.com/enyojs/enyo/pull/523
- https://github.com/enyojs/layout/pull/61

Enyo-DCO-1.1-Signed-off-by: Vincent HERILIER vincent.herilier@hp.com
