### PR TITLE
ENYO-3074: Removed calls to preventTap in dragfinish handlers

### DIFF
--- a/source/RangeSlider.js
+++ b/source/RangeSlider.js
@@ -184,7 +184,6 @@ enyo.kind({
 	},
 	dragfinish: function(inSender, inEvent) {
 		this.dragging = false;
-		inEvent.preventTap();
 		var val;
 		if (inSender.name === "startKnob") {
 			val = this.calcRangeRatio(this.beginValue);

--- a/source/Slider.js
+++ b/source/Slider.js
@@ -96,7 +96,6 @@ enyo.kind({
 	},
 	dragfinish: function(inSender, inEvent) {
 		this.dragging = false;
-		inEvent.preventTap();
 		this.doChange({value: this.value});
 		return true;
 	},

--- a/source/ToggleButton.js
+++ b/source/ToggleButton.js
@@ -110,8 +110,5 @@ enyo.kind({
 	},
 	dragfinish: function(inSender, inEvent) {
 		this.dragging = false;
-		if (this.dragged) {
-			inEvent.preventTap();
-		}
 	}
 });


### PR DESCRIPTION
## Issue

A `tap` event will be sent after a `dragfinish` event in a dragging context. The synthesized `dragfinish` no longer provides a `preventTap` method as part of this fix.
## Fix

Calls to `preventTap` have been removed from controls that handle `dragfinish`.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
