### PR TITLE
ENYO-3625: Fix issue with delayed :active:hover button styling in response to touch

### DIFF
--- a/css/Button.less
+++ b/css/Button.less
@@ -49,13 +49,6 @@
 	box-shadow: inset 0px 1px 0px rgba(0,0,0,0.1);
 }
 
-.onyx-button:active:hover:not([disabled]) {
-	background-image: @onyx-button-active-gradient;
-	background-position: top;
-	border-top: 1px solid rgba(15, 15, 15, 0.6);
-	box-shadow: inset 0px 1px 0px rgba(0,0,0,0.1);
-}
-
 .onyx-button[disabled] {
 	opacity: @onyx-disabled-opacity;
 	filter: alpha(opacity=@onyx-disabled-opacity-ie);

--- a/css/Icon.less
+++ b/css/Icon.less
@@ -7,15 +7,11 @@
 	vertical-align: middle;
 }
 
-.onyx-icon.onyx-icon-button.active, .onyx-icon.onyx-icon-button.pressed, .onyx-icon.onyx-icon-button:active:hover, .onyx-icon-toggle.active {
+.onyx-icon.onyx-icon-button.active, .onyx-icon.onyx-icon-button.pressed, .onyx-icon-toggle.active {
 	background-position: 0 -@onyx-icon-size;
 }
 
 .onyx-icon.disabled {
 	opacity: @onyx-disabled-opacity;
 	filter: alpha(opacity=@onyx-disabled-opacity-ie);
-}
-
-.onyx-icon.disabled:active:hover {
-	background-position: 0 0px;
 }

--- a/css/Slider.less
+++ b/css/Slider.less
@@ -19,6 +19,6 @@
 	margin: -23px -20px;
 }
 
-.onyx-slider-knob.active, .onyx-slider-knob.pressed, .onyx-slider-knob:active:hover {
+.onyx-slider-knob.active, .onyx-slider-knob.pressed {
 	background-position: 0 -40px;
 }

--- a/css/onyx.css
+++ b/css/onyx.css
@@ -64,16 +64,12 @@
 }
 .onyx-icon.onyx-icon-button.active,
 .onyx-icon.onyx-icon-button.pressed,
-.onyx-icon.onyx-icon-button:active:hover,
 .onyx-icon-toggle.active {
   background-position: 0 -32px;
 }
 .onyx-icon.disabled {
   opacity: 0.4;
   filter: alpha(opacity=40);
-}
-.onyx-icon.disabled:active:hover {
-  background-position: 0 0px;
 }
 /* Button.css */
 .onyx-button {
@@ -122,12 +118,6 @@
 */
 .onyx-button.active,
 .onyx-button.pressed {
-  background-image: url("../images/gradient-invert.png");
-  background-position: top;
-  border-top: 1px solid rgba(15, 15, 15, 0.6);
-  box-shadow: inset 0px 1px 0px rgba(0, 0, 0, 0.1);
-}
-.onyx-button:active:hover:not([disabled]) {
   background-image: url("../images/gradient-invert.png");
   background-position: top;
   border-top: 1px solid rgba(15, 15, 15, 0.6);
@@ -956,8 +946,7 @@
   margin: -23px -20px;
 }
 .onyx-slider-knob.active,
-.onyx-slider-knob.pressed,
-.onyx-slider-knob:active:hover {
+.onyx-slider-knob.pressed {
   background-position: 0 -40px;
 }
 /* RangeSlider.css */

--- a/source/Button.js
+++ b/source/Button.js
@@ -18,34 +18,28 @@ enyo.kind({
 	name: "onyx.Button",
 	kind: "enyo.Button",
 	classes: "onyx-button enyo-unselectable",
-	//* @protected
-	create: function() {
-		//workaround for FirefoxOS which doesn't support :active:hover css selectors
-		//FirefoxOS simulator does :active:hover css selectors, so do additional srcEvent check
-		if(enyo.platform.firefoxOS) {
-			this.handlers.ondown = "fxosDown";
-			this.handlers.onenter = "fxosEnter";
-			this.handlers.ondrag = "fxosDrag";
-			this.handlers.onleave = "fxosLeave";
-			this.handlers.onup = "fxosUp";
-		}
-		this.inherited(arguments);
+	handlers: {
+		ondown: "down",
+		onenter: "enter",
+		ondrag: "drag",
+		onleave: "leave",
+		onup: "up"
 	},
-	fxosDown: function(inSender, inEvent) {
+	down: function(inSender, inEvent) {
 		this.addClass("pressed");
 		this._isInControl = true;
 	},
-	fxosEnter: function(inSender, inEvent) {
+	enter: function(inSender, inEvent) {
 		this._isInControl = true;
 	},
-	fxosDrag: function(inSender, inEvent) {
+	drag: function(inSender, inEvent) {
 		this.addRemoveClass("pressed", this._isInControl);
 	},
-	fxosLeave: function(inSender, inEvent) {
+	leave: function(inSender, inEvent) {
 		this.removeClass("pressed");
 		this._isInControl = false;
 	},
-	fxosUp: function(inSender, inEvent) {
+	up: function(inSender, inEvent) {
 		this.removeClass("pressed");
 		this._isInControl = false;
 	}

--- a/source/IconButton.js
+++ b/source/IconButton.js
@@ -21,36 +21,12 @@ enyo.kind({
 		active: false
 	},
 	classes: "onyx-icon-button",
-	//* @protected
-	create: function() {
-		//workaround for FirefoxOS which doesn't support :active:hover css selectors
-		//FirefoxOS simulator does :active:hover css selectors, so do additional srcEvent check
-		if(enyo.platform.firefoxOS) {
-			this.handlers.ondown = "fxosDown";
-			this.handlers.onenter = "fxosEnter";
-			this.handlers.ondrag = "fxosDrag";
-			this.handlers.onleave = "fxosLeave";
-			this.handlers.onup = "fxosUp";
-		}
-		this.inherited(arguments);
-	},
-	fxosDown: function(inSender, inEvent) {
-		this.addClass("pressed");
-		this._isInControl = true;
-	},
-	fxosEnter: function(inSender, inEvent) {
-		this._isInControl = true;
-	},
-	fxosDrag: function(inSender, inEvent) {
-		this.addRemoveClass("pressed", this._isInControl);
-	},
-	fxosLeave: function(inSender, inEvent) {
-		this.removeClass("pressed");
-		this._isInControl = false;
-	},
-	fxosUp: function(inSender, inEvent) {
-		this.removeClass("pressed");
-		this._isInControl = false;
+	handlers: {
+		ondown: "down",
+		onenter: "enter",
+		ondrag: "drag",
+		onleave: "leave",
+		onup: "up"
 	},
 	rendered: function() {
 		this.inherited(arguments);
@@ -61,6 +37,24 @@ enyo.kind({
 			return true;
 		}
 		this.setActive(true);
+	},
+	down: function(inSender, inEvent) {
+		this.addClass("pressed");
+		this._isInControl = true;
+	},
+	enter: function(inSender, inEvent) {
+		this._isInControl = true;
+	},
+	drag: function(inSender, inEvent) {
+		this.addRemoveClass("pressed", this._isInControl);
+	},
+	leave: function(inSender, inEvent) {
+		this.removeClass("pressed");
+		this._isInControl = false;
+	},
+	up: function(inSender, inEvent) {
+		this.removeClass("pressed");
+		this._isInControl = false;
 	},
 	activeChanged: function() {
 		this.bubble("onActivate");

--- a/source/RangeSlider.js
+++ b/source/RangeSlider.js
@@ -85,6 +85,11 @@ enyo.kind({
 			this.$.startKnob.createComponent({name: "startLabel", kind: "onyx.RangeSliderKnobLabel"});
 			this.$.endKnob.createComponent({name: "endLabel", kind: "onyx.RangeSliderKnobLabel"});
 		}
+		// add handlers for up/down events on knobs for pressed state (workaround for inconsistent (timing-wise) active:hover styling)
+		this.$.startKnob.ondown = "knobDown";
+		this.$.startKnob.onup = "knobUp";
+		this.$.endKnob.ondown = "knobDown";
+		this.$.endKnob.onup = "knobUp";
 	},
 	refreshRangeSlider: function() {
 		// Calculate range percentages, in order to position sliders
@@ -146,6 +151,7 @@ enyo.kind({
 		if (inEvent.horizontal) {
 			inEvent.preventDefault();
 			this.dragging = true;
+			inSender.addClass("pressed");
 			return true;
 		}
 	},
@@ -193,7 +199,14 @@ enyo.kind({
 			val = this.calcRangeRatio(this.endValue);
 			this.doChange({value: val, startChanged: false});
 		}
+		inSender.removeClass("pressed");
 		return true;
+	},
+	knobDown: function(inSender, inEvent) {
+		inSender.addClass("pressed");
+	},
+	knobUp: function(inSender, inEvent) {
+		inSender.removeClass("pressed");
 	},
 	rangeMinChanged: function() {
 		this.refreshRangeSlider();

--- a/source/Slider.js
+++ b/source/Slider.js
@@ -51,15 +51,11 @@ enyo.kind({
 	],
 	create: function() {
 		this.inherited(arguments);
-		//workaround for FirefoxOS which doesn't support :active:hover css selectors
-		//FirefoxOS simulator does :active:hover css selectors, so do additional srcEvent check
-		if(enyo.platform.firefoxOS) {
-			this.moreComponents[2].ondown = "fxosDown";
-			this.moreComponents[2].onenter = "fxosEnter";
-			this.moreComponents[2].ondrag = "fxosDrag";
-			this.moreComponents[2].onleave = "fxosLeave";
-			this.moreComponents[2].onup = "fxosUp";
-		}
+
+		// add handlers for up/down events on knob for pressed state (workaround for inconsistent (timing-wise) active:hover styling)
+		this.moreComponents[2].ondown = "knobDown";
+		this.moreComponents[2].onup = "knobUp";
+
 		this.createComponents(this.moreComponents);
 		this.valueChanged();
 	},
@@ -82,6 +78,7 @@ enyo.kind({
 		if (inEvent.horizontal) {
 			inEvent.preventDefault();
 			this.dragging = true;
+			inSender.addClass("pressed");
 			return true;
 		}
 	},
@@ -98,6 +95,7 @@ enyo.kind({
 		this.dragging = false;
 		inEvent.preventTap();
 		this.doChange({value: this.value});
+		inSender.removeClass("pressed");
 		return true;
 	},
 	tap: function(inSender, inEvent) {
@@ -109,23 +107,11 @@ enyo.kind({
 			return true;
 		}
 	},
-	fxosDown: function(inSender, inEvent) {
+	knobDown: function(inSender, inEvent) {
 		this.$.knob.addClass("pressed");
-		this._isInControl = true;
 	},
-	fxosEnter: function(inSender, inEvent) {
-		this._isInControl = true;
-	},
-	fxosDrag: function(inSender, inEvent) {
-		this.$.knob.addRemoveClass("pressed", this._isInControl);
-	},
-	fxosLeave: function(inSender, inEvent) {
+	knobUp: function(inSender, inEvent) {
 		this.$.knob.removeClass("pressed");
-		this._isInControl = false;
-	},
-	fxosUp: function(inSender, inEvent) {
-		this.$.knob.removeClass("pressed");
-		this._isInControl = false;
 	},
 	//* @public
 	//* Animates to the given value.


### PR DESCRIPTION
## Issue

There is a delay in triggering `:active:hover` states in recent versions of Chrome for Android.
## Fix

All `:active:hover` styling has been removed, with the `pressed` class being used for `Onyx.Button`, `Onyx.IconButton`, and `Onyx.Slider` by consolidating the FirefoxOS workaround of adding/removing the `pressed` class during the appropriate events. Additionally, `Onyx.RangeSlider` had not been given this workaround previously and was updated as well. Lastly, there were some existing pressed state issues with the sliders, which have also been resolved via the event handlers (the slider knob would lose the pressed state while being dragged if the drag position was no longer on the knob, even if dragging was still active; this behavior seems appropriate for buttons but not slider knobs as the knob is still changing the state of the slider).

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
