### PR TITLE
ENYO-3696: TabBarItem making unnecessary render call

### DIFF
--- a/source/TabBarItem.js
+++ b/source/TabBarItem.js
@@ -102,7 +102,6 @@ enyo.kind ({
 		}
 
 		this.$.button.applyStyle('width', width + 'px');
-		this.$.button.render();
 	},
 
 	requestSwitch: function(inSender, inEvent) {


### PR DESCRIPTION
## Issue

The `render` call on the `TabBarItem` button causes issues when the button is customized to contain components that are floating; these floating components lose their owner because they are not re-generated when render is called.
## Fix

The `render` call is unnecessary as `applyStyle` already applies the width changes on the node.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
