### PR TITLE
Publish the defaultZ property.

### DIFF
--- a/source/Popup.js
+++ b/source/Popup.js
@@ -29,9 +29,7 @@ enyo.kind({
 			other popups.
 		*/
 		scrimClassName: "",
-		/**
-		 	Lowest z-index that can be applied to a popup.
-		 */
+		//* Lowest z-index that can be applied to a popup.
 		defaultZ: 120
 	},
 	//* @protected


### PR DESCRIPTION
When using the Onyx library with another UI system like Bootstrap3, I found it useful to be able to adjust the defaultZ value to be greater than some floating elements on my page.

Enyo-DCO-1.1-Signed-off-by: Matt Schott glitchtechscience@gmail.com
