### PR TITLE
ENYO-3928: Make unchecking the alwaysLooksFocused checkbox take action.

### DIFF
--- a/samples/InputSample.js
+++ b/samples/InputSample.js
@@ -64,7 +64,7 @@ enyo.kind({
 			// If disabling alwaysLooksFocused, we need to blur the
 			// InputDecorator for the setting to go into effect
 			if (!inSender.getValue()) {
-				enyo.triggerHandler(inItem, "onblur");
+				inItem.triggerHandler("onblur");
 			}
 		});
 	}


### PR DESCRIPTION
## Issue

Unchecking the `alwaysLooksFocused` checkbox does not cause the input fields to have focus removed.
## Fix

We trigger the blur event on the input fields if the `alwaysLooksFocused` checkbox is unchecked. Additionally, the `onyx.InputDecorator` around the checkbox has been removed.

This is dependent on an Enyo PR: https://github.com/enyojs/enyo/pull/687

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
