### PR TITLE
ENYO-3927: Prevent pressed state from appearing for disabled button.

### DIFF
--- a/source/Button.js
+++ b/source/Button.js
@@ -26,22 +26,37 @@ enyo.kind({
 		onup: "up"
 	},
 	down: function(inSender, inEvent) {
+		if (this.disabled) {
+			return true;
+		}
 		this.addClass("pressed");
 		this._isPressed = true;
 	},
 	enter: function(inSender, inEvent) {
+		if (this.disabled) {
+			return true;
+		}
 		if(this._isPressed) {
 			this.addClass("pressed");
 		}
 	},
 	dragfinish: function(inSender, inEvent) {
+		if (this.disabled) {
+			return true;
+		}
 		this.removeClass("pressed");
 		this._isPressed = false;
 	},
 	leave: function(inSender, inEvent) {
+		if (this.disabled) {
+			return true;
+		}
 		this.removeClass("pressed");
 	},
 	up: function(inSender, inEvent) {
+		if (this.disabled) {
+			return true;
+		}
 		this.removeClass("pressed");
 		this._isPressed = false;
 	}


### PR DESCRIPTION
## Issue

Disabled buttons are still displaying the pressed state when tapped; only seems to occur on mobile devices.
## Fix

We detect if the button is disabled and refrain from adding/removing the `pressed` class as necessary.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
