### PR TITLE
Prevent tap propagation to controls below this one

### DIFF
--- a/source/MenuItem.js
+++ b/source/MenuItem.js
@@ -56,10 +56,11 @@ enyo.kind({
 			this.bubble("onActivate");
 		}
 	},
-	tap: function(inSender) {
+	tap: function(inSender, inEvent) {
 		this.inherited(arguments);
 		this.bubble("onRequestHideMenu");
 		this.doSelect({selected:this, content:this.content});
+		inEvent.preventDefault();
 	},
 	contentChanged: function(inOld){
 		this.inherited(arguments);


### PR DESCRIPTION
Currently, tapping on a menuItem floating over inputs cause the input to get focus on mobile devices. This fix prevents this behaviour.