### PR TITLE
ENYO-4061: RangeSlider throws initialization error.

### DIFF
--- a/source/RangeSlider.js
+++ b/source/RangeSlider.js
@@ -244,7 +244,7 @@
 		/**
 		* @private
 		*/
-		begvalueChanged: function (sliderPos) {
+		beginValueChanged: function (sliderPos) {
 			if (sliderPos === undefined) {
 				var p = this.calcPercent(this.beginValue);
 				this.updateKnobPosition(p, this.$.startKnob);


### PR DESCRIPTION
## Issue

The `onyx.RangeSlider` throws an error upon initialization.
## Fix

Correct the name of a method that was inadvertently renamed.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam aaron.tam@lge.com
