### PR TITLE
ENYO-60: Onyx button elements no longer have a forced line-height.

### DIFF
--- a/css/onyx-rules.less
+++ b/css/onyx-rules.less
@@ -13,7 +13,7 @@
 }
 
 /* prevent IE from inheriting line-height for these elements */
-.onyx button, .onyx label, .onyx input {
+.onyx-button, .onyx label, .onyx input {
 	line-height: normal;
 }
 

--- a/css/onyx.css
+++ b/css/onyx.css
@@ -42,7 +42,7 @@
   -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 }
 /* prevent IE from inheriting line-height for these elements */
-.onyx button,
+.onyx-button,
 .onyx label,
 .onyx input {
   line-height: normal;


### PR DESCRIPTION
This corrects an issue regarding onyx applying presumptuous rules to all child button elements, which interferes with other libraries.

Enyo-DCO-1.1-Signed-off-by: Blake Stephens blake.stephens@lge.com
