### PR TITLE
Fixes ENYO-381

### DIFF
--- a/source/DatePicker.js
+++ b/source/DatePicker.js
@@ -135,8 +135,8 @@
 		*/
 		create: function () {
 			this.inherited(arguments);
-			if (ilib) {
-				this.locale = ilib.getLocale();
+			if (scope.ilib) {
+				this.locale = scope.ilib.getLocale();
 			}
 			this.initDefaults();
 		},
@@ -150,17 +150,14 @@
 		initDefaults: function () {
 			var months;
 			//Attempt to use the ilib library if it is loaded
-			if (ilib) {
+			if (scope.ilib) {
 				months = [];
-				this._tf = new ilib.DateFmt({locale:this.locale, timezone: 'local'});
+				this._tf = new scope.ilib.DateFmt({locale:this.locale, timezone: 'local'});
 				months = this._tf.getMonthsOfYear({length: 'long'});
 			}
 			// Fall back to en_US as default
 			else {
 				months = [undefined, 'JAN', 'FEB', 'MAR', 'APR', 'MAY', 'JUN', 'JUL', 'AUG', 'SEP', 'OCT', 'NOV', 'DEC'];
-				this.localeInfo.getMonthsOfYear = function () {
-					return months;
-				};
 			}
 
 			// use iLib's getTemplate as that returns locale-specific ordering

--- a/source/TimePicker.js
+++ b/source/TimePicker.js
@@ -96,8 +96,8 @@
 		*/
 		create: function () {
 			this.inherited(arguments);
-			if (ilib) {
-				this.locale = ilib.getLocale();
+			if (scope.ilib) {
+				this.locale = scope.ilib.getLocale();
 			}
 			this.initDefaults();
 		},
@@ -110,11 +110,11 @@
 			this._strAm = 'AM';
 			this._strPm = 'PM';
 			// Attempt to use the ilib lib (ie assume it is loaded)
-			if (ilib) {
-				this._tf = new ilib.DateFmt({locale:this.locale});
+			if (scope.ilib) {
+				this._tf = new scope.ilib.DateFmt({locale:this.locale});
 
-				var objAmPm = new ilib.DateFmt({locale:this.locale, type: 'time', template: 'a'});
-				var timeobj = ilib.Date.newInstance({locale:this.locale, hour: 1});
+				var objAmPm = new scope.ilib.DateFmt({locale:this.locale, type: 'time', template: 'a'});
+				var timeobj = scope.ilib.Date.newInstance({locale:this.locale, hour: 1});
 				this._strAm = objAmPm.format(timeobj);
 				timeobj.hour = 13;
 				this._strPm = objAmPm.format(timeobj);


### PR DESCRIPTION
## Issue

DatePicker and TimePicker check for existence of ilib but the variable is undefined if ilib has not been included
## Fix

Properly scope existence check for ilib

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
