### PR TITLE
Fixes ENYO-602

### DIFF
--- a/source/ContextualPopup.js
+++ b/source/ContextualPopup.js
@@ -286,6 +286,9 @@
 				if (this.scrolling) {
 					this.getScroller().setShowing(this.showing);
 				}
+				if (!this.showing) {
+					this.activator = this.activatorOffset = null;
+				}
 				this.adjustPosition();
 			};
 		}),
@@ -304,10 +307,7 @@
 		* @private
 		*/
 		requestShow: function (sender, event) {
-			var n = event.activator.hasNode();
-			if (n) {
-				this.activatorOffset = this.getPageOffset(n);
-			}
+			this.activator = event.activator.hasNode();
 			this.show();
 			return true;
 		},
@@ -395,8 +395,9 @@
 		* @private
 		*/
 		adjustPosition: function () {
-			if (this.showing && this.hasNode()) {
+			if (this.showing && this.hasNode() && this.activator) {
 				this.resetPositioning();
+				this.activatorOffset = this.getPageOffset(this.activator);
 				var innerWidth = this.getViewWidth();
 				var innerHeight = this.getViewHeight();
 


### PR DESCRIPTION
## Issue

The position of the activator is retrieved and cached when the popup is shown. When you resize the window after the popup is showing (and the activator's absolute position changes as well), the popup is repositioned based on where the activator was and not where it is.
## Fix

Cache a reference to the activator and refresh position during resize handler

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)
