### PR TITLE
Fixes ENYO-1141

### DIFF
--- a/samples/SliderSample.js
+++ b/samples/SliderSample.js
@@ -1,55 +1,72 @@
 enyo.kind({
-	name: "onyx.sample.SliderSample",
-	classes: "onyx onyx-sample",
+	name: 'onyx.sample.SliderSample',
+	classes: 'onyx onyx-sample',
 	components: [
-		{classes: "onyx-sample-divider", content: "Sliders"},
-		{kind: "onyx.Slider", value: 50, onChanging:"sliderChanging", onChange:"sliderChanged"},
-		{tag: "br"},
-		{kind: "onyx.Slider", lockBar: false, value: 50, onChanging:"sliderChanging", onChange:"sliderChanged"},
+		{classes: 'onyx-sample-divider', content: 'Sliders'},
+		{kind: 'onyx.Slider', value: 50, onChanging:'sliderChanging', onChange:'sliderChanged'},
+		{tag: 'br'},
+		{kind: 'onyx.Slider', lockBar: false, value: 50, onChanging:'sliderChanging', onChange:'sliderChanged'},
 
-		{tag: "br"},
-		{kind: "onyx.InputDecorator", style:"margin-right:10px;", components: [
-			{kind: "onyx.Input", placeholder: "Value", style:"width:50px;"}
+		{tag: 'br'},
+		{kind: 'onyx.InputDecorator', style:'margin-right:10px;', components: [
+			{kind: 'onyx.Input', placeholder: 'Value', style:'width:50px;'}
 		]},
-		{kind: "onyx.Button", content:"Set", classes:"onyx-sample-spaced-button", ontap:"changeValue"},
-		{kind: "onyx.Button", content:"-", classes:"onyx-sample-spaced-button", ontap:"decValue"},
-		{kind: "onyx.Button", content:"+", classes:"onyx-sample-spaced-button", ontap:"incValue"},
-		{tag: "br"},
-		{tag: "br"},
-		{kind: "onyx.Checkbox", name:"animateSetting", value:true},
-		{content:"Animated", classes:"enyo-inline onyx-sample-animate-label"},
-		{name : "incrementSetting", kind: "onyx.Checkbox", onchange: "sliderIncrementChanged", checked: false},
-		{content: "increment by 7", classes:"enyo-inline"},
-		{tag: "br"},
-		{tag: "br"},
-		{kind: "onyx.Groupbox", classes:"onyx-sample-result-box", components: [
-			{kind: "onyx.GroupboxHeader", content: "Result"},
-			{name:"result", classes:"onyx-sample-result", content:"No slider moved yet."}
+		{kind: 'onyx.Button', content:'Set', classes:'onyx-sample-spaced-button', ontap:'changeValue'},
+		{kind: 'onyx.Button', content:'-', classes:'onyx-sample-spaced-button', ontap:'decValue'},
+		{kind: 'onyx.Button', content:'+', classes:'onyx-sample-spaced-button', ontap:'incValue'},
+		{tag: 'br'},
+		{tag: 'br'},
+		{kind: 'onyx.Checkbox', name:'animateSetting', value:true},
+		{content:'Animated', classes:'enyo-inline onyx-sample-animate-label'},
+		{name : 'incrementSetting', kind: 'onyx.Checkbox', onchange: 'sliderIncrementChanged', checked: false},
+		{content: 'increment by 7', classes:'enyo-inline'},
+		{tag: 'br'},
+		{tag: 'br'},
+		{kind: 'onyx.Groupbox', classes:'onyx-sample-result-box', components: [
+			{kind: 'onyx.GroupboxHeader', content: 'Result'},
+			{name:'result', classes:'onyx-sample-result', content:'No slider moved yet.'}
 		]},
-		{tag: "br"},
-		{tag: "br"},
-		{tag: "br"},
-		{classes: "onyx-sample-divider", content: "RangeSlider"},
-		{tag: "br"},
-		{kind: "onyx.RangeSlider", rangeMin: 100, rangeMax: 500, rangeStart: 200, rangeEnd: 400, increment: 20, showLabels: true, onChanging: "rangeSliderChanging", onChange: "rangeSliderChanged"},
+		{tag: 'br'},
+		{tag: 'br'},
+		{tag: 'br'},
+		{classes: 'onyx-sample-divider', content: 'RangeSlider'},
+		{tag: 'br'},
+		{kind: 'onyx.RangeSlider', rangeMin: 100, rangeMax: 500, rangeStart: 200, rangeEnd: 400, increment: 20, showLabels: true, onChanging: 'rangeSliderChanging', onChange: 'rangeSliderChanged'},
 		{components: [
-			{style: "width:20%; display:inline-block; text-align:left;", content: "$100"},
-			{style: "width:60%; display:inline-block; text-align:center;", content: "$300"},
-			{style: "width:20%; display:inline-block; text-align:right;", content: "$500"}
+			{style: 'width:20%; display:inline-block; text-align:left;', content: '$100'},
+			{style: 'width:60%; display:inline-block; text-align:center;', content: '$300'},
+			{style: 'width:20%; display:inline-block; text-align:right;', content: '$500'}
 		]},
-		{tag: "br"},
-		{kind: "onyx.Checkbox", onchange: "rangeSliderIncrementChanged", checked: true},
-		{content: "increment by 20", classes:"enyo-inline"},
-		{tag: "br"},
-		{tag: "br"},
-		{kind: "onyx.Groupbox", classes:"onyx-sample-result-box", components: [
-			{kind: "onyx.GroupboxHeader", content: "Result"},
-			{name:"rangeSliderResult", classes:"onyx-sample-result", content:"RangeSlider not moved yet."}
+		{tag: 'br'},
+		{kind: 'onyx.Checkbox', onchange: 'rangeSliderIncrementChanged', checked: true},
+		{content: 'increment by 20', classes:'enyo-inline'},
+		{tag: 'br'},
+		{tag: 'br'},
+		{kind: 'onyx.Groupbox', classes:'onyx-sample-result-box', components: [
+			{kind: 'onyx.GroupboxHeader', content: 'Result'},
+			{name:'rangeSliderResult', classes:'onyx-sample-result', content:'RangeSlider not moved yet.'}
+		]},
+		{tag: 'br'},
+		{tag: 'br'},
+		{tag: 'br'},
+		{classes: 'onyx-sample-divider', content: 'Slider (Bound Value)'},
+		{tag: 'br'},
+		{kind: 'onyx.Slider', name: 'boundSlider', value: 50},
+		{tag: 'br'},
+		{tag: 'br'},
+		{kind: 'onyx.Groupbox', classes:'onyx-sample-result-box', components: [
+			{kind: 'onyx.GroupboxHeader', content: 'Result'},
+			{name:'boundResult', classes:'onyx-sample-result'}
 		]}
+	],
+	bindings: [
+		{from: '$.boundSlider.value', to: '$.boundResult.content', transform: function (val) {
+			return enyo.format('Current value: %.', val);
+		}}
 	],
 	changeValue: function(inSender, inEvent) {
 		for (var i in this.$) {
-			if (this.$[i].kind == "onyx.Slider") {
+			if (this.$[i].kind == 'onyx.Slider') {
 				if (this.$.animateSetting.getValue()) {
 					this.$[i].animateTo(this.$.input.getValue());
 				} else {
@@ -59,20 +76,20 @@ enyo.kind({
 		}
 	},
 	incValue: function() {
-		var tGap = (this.$.incrementSetting.getChecked()) ? 7 : 10;	
+		var tGap = (this.$.incrementSetting.getChecked()) ? 7 : 10;
 		this.$.input.setValue(Math.min(parseInt(this.$.input.getValue() || 0, 10) + tGap, 100));
 		this.changeValue();
 	},
 	decValue: function() {
-		var tGap = (this.$.incrementSetting.getChecked()) ? 7 : 10;	
+		var tGap = (this.$.incrementSetting.getChecked()) ? 7 : 10;
 		this.$.input.setValue(Math.max(parseInt(this.$.input.getValue() || 0, 10) - tGap, 0));
 		this.changeValue();
 	},
 	sliderChanging: function(inSender, inEvent) {
-		this.$.result.setContent(inSender.name + " changing: " + Math.round(inSender.getValue()));
+		this.$.result.setContent(inSender.name + ' changing: ' + Math.round(inSender.getValue()));
 	},
 	sliderChanged: function(inSender, inEvent) {
-		this.$.result.setContent(inSender.name + " changed to " + Math.round(inSender.getValue()) + ".");
+		this.$.result.setContent(inSender.name + ' changed to ' + Math.round(inSender.getValue()) + '.');
 	},
 	rangeSliderIncrementChanged: function(inSender, inEvent) {
 		this.$.rangeSlider.setIncrement(inSender.getValue() ? 20 : 0);
@@ -82,16 +99,16 @@ enyo.kind({
 		this.$.slider.setIncrement(inSender.getValue() ? 7 : 0);
 	},
 	updateRangeLabels: function(slider) {
-		slider.setStartLabel("--> " + Math.floor(slider.getRangeStart()));
-		slider.setEndLabel(Math.ceil(slider.getRangeEnd()) + "<--");
+		slider.setStartLabel('--> ' + Math.floor(slider.getRangeStart()));
+		slider.setEndLabel(Math.ceil(slider.getRangeEnd()) + '<--');
 	},
 	rangeSliderChanging: function(inSender, inEvent) {
 		this.updateRangeLabels(inSender);
-		this.$.rangeSliderResult.setContent("Range changing: $" + Math.round(inSender.getRangeStart()) + " - $" + Math.round(inSender.getRangeEnd()));
+		this.$.rangeSliderResult.setContent('Range changing: $' + Math.round(inSender.getRangeStart()) + ' - $' + Math.round(inSender.getRangeEnd()));
 	},
 	rangeSliderChanged: function(inSender, inEvent) {
 		this.updateRangeLabels(inSender);
-		this.$.rangeSliderResult.setContent("Range changed to $" + Math.round(inSender.getRangeStart()) + " - $" + Math.round(inSender.getRangeEnd()) + ".");
+		this.$.rangeSliderResult.setContent('Range changed to $' + Math.round(inSender.getRangeStart()) + ' - $' + Math.round(inSender.getRangeEnd()) + '.');
 	},
 	create: function() {
 		this.inherited(arguments);

--- a/samples/SliderSample.js
+++ b/samples/SliderSample.js
@@ -1,5 +1,6 @@
 enyo.kind({
 	name: 'onyx.sample.SliderSample',
+	kind: 'Scroller',
 	classes: 'onyx onyx-sample',
 	components: [
 		{classes: 'onyx-sample-divider', content: 'Sliders'},

--- a/source/Slider.js
+++ b/source/Slider.js
@@ -153,10 +153,19 @@
 		*/
 		valueChanged: function () {
 			this.value = this.clampValue(this.min, this.max, this.value);
-			var p = this.calcPercent(this.value);
+			if (!this.$.animator.isAnimating()) {
+				this.updateBar(this.value);
+			}
+		},
+
+		/**
+		* @private
+		*/
+		updateBar: function (value) {
+			var p = this.calcPercent(value);
 			this.updateKnobPosition(p);
 			if (this.lockBar) {
-				this.setProgress(this.value);
+				this.setProgress(value);
 			}
 		},
 
@@ -195,7 +204,7 @@
 			if (this.dragging) {
 				var v = this.calcKnobPosition(event);
 				v = (this.increment) ? this.calcIncrement(v) : v;
-				this.setValue(v);
+				this.setValue(this.clampValue(this.min, this.max, v));
 				this.doChanging({value: this.value});
 				return true;
 			}
@@ -253,13 +262,15 @@
 				endValue: value,
 				node: this.hasNode()
 			});
+
+			this.setValue(value);
 		},
 
 		/**
 		* @private
 		*/
 		animatorStep: function (sender) {
-			this.setValue(sender.value);
+			this.updateBar(sender.value);
 			return true;
 		},
 


### PR DESCRIPTION
## Issue
If you drag beyond the bounds of the slider, the knob doesn't move but the value is updated to the out of bounds value and observers are notified before it can be corrected in valueChanged. Also, when tapping the bar, the value is updated when the animator steps rather than just updating to final value.

## Fix
Clamp the value in the drag handler to ensure it stays within bounds.
Refactor things a bit so the animator can update the knob and progress position without incrementally changing the value.

Enyo-DCO-1.1-Signed-off-by: Ryan Duffy (ryan.duffy@lge.com)