### PR TITLE
ENYO-2979: Fix incorrect image asset paths.

### DIFF
--- a/css/onyx-variables.less
+++ b/css/onyx-variables.less
@@ -142,3 +142,6 @@
 @onyx-spinner-light-image: url("@{onyx-image-path}/spinner-light.gif");
 @onyx-spinner-image-width: 59px;
 @onyx-spinner-image-height: 58px;
+
+@onyx-close-inactive-image: url("@{onyx-image-path}/close-inactive.png");
+@onyx-close-active-image: url("@{onyx-image-path}/close-active.png");

--- a/src/TabBarItem/TabBarItem.less
+++ b/src/TabBarItem/TabBarItem.less
@@ -57,7 +57,7 @@
 	top: 2px;
 	right: 19px; // to place it left of close button
 	position: absolute;
-	
+
 	.onyx-tab-item-gradient( fadeout(@tab-inactive,100%), @tab-inactive);
 
 	&.active {
@@ -77,8 +77,8 @@
 	height: 16px;
 	vertical-align: middle;
 	background-repeat: no-repeat;
-	background-image: url('@{onyx-image-path}/close-inactive.png');
+	background-image: @onyx-close-inactive-image;
 	&:hover {
-		background-image: url('@{onyx-image-path}/close-active.png');
+		background-image: @onyx-close-active-image;
 	}
 }


### PR DESCRIPTION
### Issue
When we moved controls to the `src` subfolder, the image paths were relative to the root and thus were broken.

### Fix
We have moved the `onyx/TabBar` image paths to variables in `onyx-variables.less` both for consistency and to not have to deal with relative paths from nested LESS files.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>