### PR TITLE
ENYO-2987: Increase specificity of rules.

### DIFF
--- a/css/onyx-rules.less
+++ b/css/onyx-rules.less
@@ -10,37 +10,37 @@
 	background-color: @onyx-background;
 	/* remove automatic tap highlight color */
 	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-}
 
-/* prevent IE from inheriting line-height for these elements */
-.onyx-button, .onyx label, .onyx input {
-	line-height: normal;
-}
+	/* prevent IE from inheriting line-height for these elements */
+	.onyx-button, .onyx label, .onyx input {
+		line-height: normal;
+	}
 
-.onyx-selected {
-	background-color: @onyx-selected-background;
+	.onyx-selected {
+		background-color: @onyx-selected-background;
+	}
+
+	/* some default colors */
+	.onyx-dark {
+		background-color: @onyx-dark-background;
+	}
+
+	.onyx-light {
+		background-color: @onyx-light-background;
+	}
+
+	.onyx-green {
+		background-color: #91BA07;
+	}
+
+	.onyx-red {
+		background-color: #C51616;
+	}
+
+	.onyx-blue {
+		background-color: #35A8EE;
+	}
 }
 
 /* LESS pre-calculations */
 @onyx-disabled-opacity-ie: @onyx-disabled-opacity*100;
-
-/* some default colors */
-.onyx-dark {
-	background-color: @onyx-dark-background;
-}
-
-.onyx-light {
-	background-color: @onyx-light-background;
-}
-
-.onyx-green {
-	background-color: #91BA07;
-}
-
-.onyx-red {
-	background-color: #C51616;
-}
-
-.onyx-blue {
-	background-color: #35A8EE;
-}

--- a/index.js
+++ b/index.js
@@ -1,7 +1,10 @@
 /**
 * Features a variety of commonly used widgets, including toolbars, text inputs, checkboxes, groups
-* and multiple types of buttons. 
+* and multiple types of buttons.
 *
-* @namespace onyx 
+* @namespace onyx
 */
 module.exports.version = "2.6.0-rc.1";
+
+var dom = require('enyo/dom');
+dom.addBodyClass('onyx');


### PR DESCRIPTION
### Issue
Due to non-guaranteed processing of LESS files, the low-specificity of several `onyx` color rules were being overwritten.

### Fix
We have nested all of these rules in the `onyx` selector as that seemed the most logical.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>