### PR TITLE
ENYO-3180: Use local timezone for meridiem calculation.

### DIFF
--- a/src/i18n/TimePicker.js
+++ b/src/i18n/TimePicker.js
@@ -80,12 +80,12 @@ module.exports = kind(
 	* @private
 	*/
 	setupMeridiems: function () {
-		var objAmPm = new DateFmt({locale: this.locale, type: 'time', template: 'a'}),
-			timeobj = dateFactory({locale: this.locale, hour: 1});
+		var objAmPm = new DateFmt({locale: this.locale, timezone: 'local', type: 'time', template: 'a'}),
+			timeobj = dateFactory({locale: this.locale, timezone: 'local', hour: 1});
 
 		this._strAm = objAmPm.format(timeobj);
 		// TODO: Does not support locales with more than two meridiems.  See moonstone/TimePicker
-		timeobj.hour = 13;
+		timeobj.setHours(13);
 		this._strPm = objAmPm.format(timeobj);
 
 		if (this.is24HrMode == null) {


### PR DESCRIPTION
### Issue
In `onyx/TimePicker`, we rely on the locale to determine the timezone, when determining the meridiem strings. On the TV, this was problematic because the timezone data files could not be accessed in the sampler application, because of CORS. The default behavior of `ilib` is to default to `Etc/UTC` in these instances, while `DateFactory` utilizes the timezone associated with the locale, which is not `Etc/UTC` in this case. This mismatch results in `ilib` attempting to use a Rata Die based calculation for formatting the date, and because we had used direct assignment for setting the hour, the Rata Die components were not properly updated as they would have been if the `setHours` setter was used.

### Fix
There is an underlying issue with why the timezone data files cannot be accessed on the TV, but I also wanted to update the `TimePicker` code to be a bit more foolproof and reliable. In addition to using the provided `setHours` setter to set the hour of the `DateFactory` time object, we have also explicitly specified the use of the `local` timezone, as we want the same timezone to be used for both `DateFmt` and `DateFactory`, in determining the meridiem strings.

Enyo-DCO-1.1-Signed-off-by: Aaron Tam <aaron.tam@lge.com>